### PR TITLE
ci: add GitHub Actions for CI, versioning, and releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Run tests
+        run: go test -v ./...
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Build
+        run: go build -v ./...

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,33 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,83 @@
+version: 2
+
+project_name: seer-cli
+
+before:
+  hooks:
+    - go mod tidy
+
+builds:
+  - id: seer-cli
+    main: .
+    binary: seer-cli
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    ignore:
+      - goos: windows
+        goarch: arm64
+    ldflags:
+      - -s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}}
+
+archives:
+  - id: seer-cli
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    format_overrides:
+      - goos: windows
+        formats: [zip]
+    files:
+      - README.md
+
+checksum:
+  name_template: "{{ .ProjectName }}_{{ .Version }}_checksums.txt"
+
+changelog:
+  sort: asc
+  use: github
+  groups:
+    - title: "New Features"
+      regexp: '^.*?feat(\(.+\))??!?:.+$'
+      order: 0
+    - title: "Bug Fixes"
+      regexp: '^.*?fix(\(.+\))??!?:.+$'
+      order: 1
+    - title: "Documentation"
+      regexp: '^.*?docs(\(.+\))??!?:.+$'
+      order: 2
+    - title: "Other Changes"
+      order: 999
+  filters:
+    exclude:
+      - "^chore:"
+      - "^ci:"
+      - "^test:"
+      - Merge pull request
+      - Merge branch
+
+release:
+  github:
+    owner: "{{ .Env.GITHUB_REPOSITORY_OWNER }}"
+    name: seer-cli
+  name_template: "v{{ .Version }}"
+  draft: false
+  prerelease: auto
+  footer: |
+    ## Installation
+
+    ### macOS / Linux
+    ```sh
+    # Download the archive for your platform, extract, and move to your PATH:
+    tar -xzf seer-cli_{{ .Version }}_<os>_<arch>.tar.gz
+    sudo mv seer-cli /usr/local/bin/
+    ```
+
+    ### Windows
+    Extract the `.zip` archive and add `seer-cli.exe` to your `PATH`.
+
+    **Full Changelog**: https://github.com/{{ .Env.GITHUB_REPOSITORY }}/compare/{{ .PreviousTag }}...{{ .Tag }}

--- a/main.go
+++ b/main.go
@@ -2,6 +2,12 @@ package main
 
 import "seer-cli/cmd"
 
+var (
+	version = "dev"
+	commit  = "none"
+	date    = "unknown"
+)
+
 func main() {
 	cmd.Execute()
 }


### PR DESCRIPTION
## Summary

- **CI workflow** (`.github/workflows/ci.yml`): runs `go test ./...` then `go build ./...` on every push/PR to `main`
- **Release workflow** (`.github/workflows/release.yml`): triggers GoReleaser when a `v*` tag is pushed
- **GoReleaser config** (`.goreleaser.yml`): builds cross-platform binaries and creates a GitHub Release with changelog and install instructions
- **`main.go`**: exposes `version`/`commit`/`date` vars populated via ldflags at build time

## Release behavior

Push a tag to trigger a release:
```sh
git tag v1.0.0
git push origin v1.0.0
```

This will:
- Build binaries for Linux, macOS, Windows (amd64 + arm64; no Windows arm64)
- Generate a grouped changelog from conventional commit messages (feat/fix/docs)
- Attach `.tar.gz`/`.zip` archives + a `checksums.txt` to the GitHub Release page
- Mark pre-releases automatically for tags like `v1.0.0-rc.1`

## Test plan

- [ ] Confirm CI workflow runs and passes on this PR
- [ ] Push a test tag (e.g. `v0.1.0`) to verify GoReleaser creates a release with binaries and changelog

🤖 Generated with [Claude Code](https://claude.com/claude-code)