### PR TITLE
docs: add conventional commits and PR convention to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,3 +88,7 @@ Global flags (`--server`, `--api-key`, `--verbose`) are bound to Viper keys `ser
 
 - **Normal mode**: Raw pretty-printed JSON only (piping to `jq` must work).
 - **Verbose mode**: Include progress messages, target URL, HTTP status code before the JSON.
+
+### Commit & PR Convention
+
+All commits and PR titles must follow [Conventional Commits](https://www.conventionalcommits.org/) — e.g. `feat(movies): add get-details command`. PR titles are squash-merged into `main` and become the commit message, so they must follow this convention too. One PR per change.


### PR DESCRIPTION
Adds a short "Commit & PR Convention" section documenting that all commits and PR titles must follow Conventional Commits, and that one PR per change is required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)