### PR TITLE
feat: add --version flag with build info

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -32,7 +32,20 @@ var (
 	server  string
 	apiKey  string
 	verbose bool
+
+	buildVersion = "dev"
+	buildCommit  = "none"
+	buildDate    = "unknown"
 )
+
+// SetVersionInfo is called from main to inject linker-set build variables.
+func SetVersionInfo(version, commit, date string) {
+	buildVersion = version
+	buildCommit = commit
+	buildDate = date
+
+	RootCmd.Version = fmt.Sprintf("%s (commit: %s, built: %s)", buildVersion, buildCommit, buildDate)
+}
 
 var RootCmd = &cobra.Command{
 	Use:   "seer-cli",

--- a/main.go
+++ b/main.go
@@ -9,5 +9,6 @@ var (
 )
 
 func main() {
+	cmd.SetVersionInfo(version, commit, date)
 	cmd.Execute()
 }


### PR DESCRIPTION
Wires the linker-injected `version`, `commit`, and `date` variables into Cobra's built-in `--version` flag.

```
# local build
$ seer-cli --version
seer-cli version dev (commit: none, built: unknown)

# release build (via GoReleaser)
$ seer-cli --version
seer-cli version 1.0.0 (commit: abc1234, built: 2026-03-13)
```

No new dependencies. Two files changed: `main.go` and `cmd/root.go`.