### PR TITLE
ci: publish AGENT.md to ClawHub as SKILL.md on merge to main

### DIFF
--- a/.github/workflows/clawhub.yml
+++ b/.github/workflows/clawhub.yml
@@ -30,6 +30,7 @@ jobs:
           clawhub publish SKILL.md \
             --slug seer-manager \
             --name "Seer server manager" \
+            --description "Manage a self-hosted Seer media server from the command line. Search movies and TV shows, create and approve media requests, manage users and permissions, track issues, control watchlists and blocklists, and query Radarr/Sonarr service integrations — all via a fast Go CLI that returns structured JSON output." \
             --version "${{ github.event.release.tag_name }}" \
             --changelog "${{ github.event.release.body }}" \
             --no-input


### PR DESCRIPTION
Adds a workflow that publishes `AGENT.md` to ClawHub as `SKILL.md` whenever a stable release is published.

**Trigger:** `release: released` — only fires for non-prerelease releases (pre-releases like `beta`/`rc` are ignored). The version and changelog are taken directly from the GitHub Release.

**Required secret:** Add `CLAWHUB_TOKEN` to repository secrets (Settings → Secrets → Actions). Generate a token via `clawhub login` locally.