### PR TITLE
fix: use published event with prerelease guard for ClawHub trigger

### DIFF
--- a/.github/workflows/clawhub.yml
+++ b/.github/workflows/clawhub.yml
@@ -2,11 +2,12 @@ name: Publish to ClawHub
 
 on:
   release:
-    types: [released]
+    types: [published]
 
 jobs:
   publish:
     name: Publish to ClawHub
+    if: github.event.release.prerelease == false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
GoReleaser creates releases via the GitHub API which emits `published`, not `released`. Switching to `published` + `if: github.event.release.prerelease == false` ensures the workflow fires for stable releases only.