### PR TITLE
fix: remove unsupported --description flag from clawhub publish

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -120,7 +120,6 @@ jobs:
           clawhub publish SKILL.md \
             --slug seer-manager \
             --name "Seer server manager" \
-            --description "Manage a self-hosted Seer media server from the command line. Search movies and TV shows, create and approve media requests, manage users and permissions, track issues, control watchlists and blocklists, and query Radarr/Sonarr service integrations — all via a fast Go CLI that returns structured JSON output." \
             --version "${{ steps.version.outputs.tag }}" \
             --changelog "Release ${{ steps.version.outputs.tag }}" \
             --no-input


### PR DESCRIPTION
The `clawhub publish` CLI does not support `--description`. The description is already defined in `AGENT.md`'s frontmatter and picked up automatically. Removing the flag fixes the exit code 1 failure.