### PR TITLE
fix: pass folder to clawhub publish instead of file path

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -116,8 +116,9 @@ jobs:
         run: |
           npm install -g clawhub
           clawhub login --token "${{ secrets.CLAWHUB_TOKEN }}"
-          cp AGENT.md SKILL.md
-          clawhub publish SKILL.md \
+          mkdir -p .clawhub-publish
+          cp AGENT.md .clawhub-publish/SKILL.md
+          clawhub publish .clawhub-publish \
             --slug seer-manager \
             --name "Seer server manager" \
             --version "${{ steps.version.outputs.tag }}" \


### PR DESCRIPTION
clawhub publish expects a folder containing SKILL.md, not a direct file path.