### PR TITLE
feat(docker): add container image and MCP HTTP server env var support

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -37,6 +37,45 @@ sudo mv seer-cli /usr/local/bin/
 
 Supports Linux and macOS (amd64 / arm64).
 
+## Docker
+
+Run the MCP HTTP server in a container next to your Seer instance:
+
+```bash
+docker run --rm \
+  -e SEER_SERVER=http://your-seer-instance:5055 \
+  -e SEER_API_KEY=your-api-key \
+  -e SEER_MCP_AUTH_TOKEN=your-secret-token \
+  -p 8811:8811 \
+  ghcr.io/electather/seer-cli:latest
+```
+
+MCP endpoint: `http://localhost:8811/mcp` — set `Authorization: Bearer your-secret-token` in your MCP client.
+
+`SEER_MCP_AUTH_TOKEN` is required for HTTP transport. Omitting it will produce an error unless you also pass `--no-auth` (insecure).
+
+### docker-compose deployment
+
+Use the included `docker-compose.yml` to deploy alongside Seer:
+
+```bash
+SEER_API_KEY=xxx SEER_MCP_AUTH_TOKEN=secret docker compose up -d
+```
+
+The default `SEER_SERVER` in the compose file points to `http://seer:5055` (the Seer service name). Override it if your Seer instance is elsewhere.
+
+### Running CLI commands via Docker
+
+Override the default CMD to run any CLI command:
+
+```bash
+docker run --rm \
+  -e SEER_SERVER=http://your-seer-instance:5055 \
+  -e SEER_API_KEY=your-api-key \
+  ghcr.io/electather/seer-cli:latest \
+  status system
+```
+
 ## Setup
 
 ```bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+# Stage 1: Build
+FROM golang:1.26-alpine AS builder
+
+WORKDIR /src
+
+# Copy workspace files
+COPY go.work go.work.sum ./
+COPY go.mod go.sum ./
+COPY pkg/api/go.mod pkg/api/go.sum ./pkg/api/
+
+# Download dependencies
+RUN go work sync && go mod download
+
+# Copy source
+COPY . .
+
+# Build static binary
+RUN CGO_ENABLED=0 go build -ldflags="-s -w" -o /seer-cli .
+
+# Stage 2: Final image
+FROM alpine:latest
+
+RUN apk add --no-cache ca-certificates
+
+COPY --from=builder /seer-cli /usr/local/bin/seer-cli
+
+EXPOSE 8811
+
+ENTRYPOINT ["seer-cli"]
+CMD ["mcp", "serve", "--transport", "http"]

--- a/cmd/mcp/serve.go
+++ b/cmd/mcp/serve.go
@@ -37,13 +37,14 @@ func init() {
 	serveCmd.Flags().Bool("no-auth", false, "Disable authentication (insecure — must be explicit)")
 	serveCmd.Flags().String("tls-cert", "", "Path to TLS certificate file")
 	serveCmd.Flags().String("tls-key", "", "Path to TLS private key file")
+	viper.BindPFlag("mcp_auth_token", serveCmd.Flags().Lookup("auth-token"))
 	Cmd.AddCommand(serveCmd)
 }
 
 func runServe(cmd *cobra.Command, args []string) error {
 	transport, _ := cmd.Flags().GetString("transport")
 	addr, _ := cmd.Flags().GetString("addr")
-	authToken, _ := cmd.Flags().GetString("auth-token")
+	authToken := viper.GetString("mcp_auth_token")
 	noAuth, _ := cmd.Flags().GetBool("no-auth")
 	tlsCert, _ := cmd.Flags().GetString("tls-cert")
 	tlsKey, _ := cmd.Flags().GetString("tls-key")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+services:
+  seer-cli:
+    build: .
+    # image: ghcr.io/electather/seer-cli:latest  # use pre-built image once published
+    environment:
+      SEER_SERVER: http://seer:5055       # or your Seer hostname
+      SEER_API_KEY: ${SEER_API_KEY}
+      SEER_MCP_AUTH_TOKEN: ${SEER_MCP_AUTH_TOKEN}
+    ports:
+      - "8811:8811"
+    restart: unless-stopped


### PR DESCRIPTION
## Summary

- Add multi-stage `Dockerfile` (builder: `golang:1.26-alpine`, final: `alpine:latest`) that builds a static binary and starts the MCP HTTP server by default
- Add `docker-compose.yml` for deploying alongside a Seer instance
- Bind `--auth-token` to Viper key `mcp_auth_token` so `SEER_MCP_AUTH_TOKEN` env var is picked up automatically
- Document Docker deployment (quick-start, compose, CLI override) in `AGENT.md`

## Test plan

- [ ] `docker build -t seer-cli .` builds successfully
- [ ] `docker run --rm -e SEER_SERVER=... -e SEER_API_KEY=... -e SEER_MCP_AUTH_TOKEN=secret -p 8811:8811 seer-cli` starts MCP HTTP server
- [ ] `docker run --rm -e SEER_SERVER=... -e SEER_API_KEY=... seer-cli status system` runs CLI command
- [ ] Omitting `SEER_MCP_AUTH_TOKEN` (and no `--no-auth`) produces the expected error
- [ ] `go test -v ./...` passes