### PR TITLE
ci(release): migrate to dockers_v2 to silence deprecation warning

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -37,29 +37,13 @@ archives:
 checksum:
   name_template: "{{ .ProjectName }}_{{ .Version }}_checksums.txt"
 
-dockers:
-  - image_templates:
-      - "ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/seer-cli:{{ .Version }}-amd64"
-    dockerfile: Dockerfile
-    use: buildx
-    build_flag_templates:
-      - "--platform=linux/amd64"
-  - image_templates:
-      - "ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/seer-cli:{{ .Version }}-arm64"
-    dockerfile: Dockerfile
-    use: buildx
-    build_flag_templates:
-      - "--platform=linux/arm64"
-
-docker_manifests:
-  - name_template: "ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/seer-cli:{{ .Version }}"
-    image_templates:
-      - "ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/seer-cli:{{ .Version }}-amd64"
-      - "ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/seer-cli:{{ .Version }}-arm64"
-  - name_template: "ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/seer-cli:latest"
-    image_templates:
-      - "ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/seer-cli:{{ .Version }}-amd64"
-      - "ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/seer-cli:{{ .Version }}-arm64"
+dockers_v2:
+  - images:
+      - "ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/seer-cli"
+    tags:
+      - "{{ .Version }}"
+      - latest
+    dockerfile: Dockerfile.release
 
 changelog:
   sort: asc

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,0 +1,12 @@
+FROM alpine:latest
+
+ARG TARGETPLATFORM
+
+RUN apk add --no-cache ca-certificates
+
+COPY $TARGETPLATFORM/seer-cli /usr/local/bin/seer-cli
+
+EXPOSE 8811
+
+ENTRYPOINT ["seer-cli"]
+CMD ["mcp", "serve", "--transport", "http"]


### PR DESCRIPTION
## Summary

- Replaces deprecated `dockers` + `docker_manifests` blocks with the new `dockers_v2` syntax
- Adds `Dockerfile.release` (no build stage) that copies the pre-built binary GoReleaser provides at `$TARGETPLATFORM/seer-cli`
- Keeps the original `Dockerfile` intact for standalone/local builds

## Test plan

- [ ] Trigger a release and confirm no deprecation warning from GoReleaser
- [ ] Confirm versioned and `latest` images are published to ghcr.io