### PR TITLE
fix(release): disable SBOM attestation for docker image build

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -44,6 +44,7 @@ dockers_v2:
       - "{{ .Version }}"
       - latest
     dockerfile: Dockerfile.release
+    sbom: false
 
 changelog:
   sort: asc


### PR DESCRIPTION
## Summary

- Adds `sbom: false` to the `dockers_v2` config in `.goreleaser.yml`

The release pipeline was failing with:

```
ERROR: failed to build: Attestation is not supported for the docker driver.
Switch to a different driver, or turn on the containerd image store, and try again.
```

goreleaser v2's `dockers_v2` enables SBOM attestation by default (`--attest=type=sbom`), which requires either the `docker-container` buildx driver with containerd image store, or attestation explicitly disabled. Disabling SBOM is the minimal fix.