### PR TITLE
ci(release): explicitly set docker-container driver for buildx

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,9 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          driver: docker-container
+          install: true
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3


### PR DESCRIPTION
## Summary

- Adds `driver: docker-container` and `install: true` to the `setup-buildx-action` step

`goreleaser` `dockers_v2` requires the `docker-container` buildx driver for multi-platform builds. The default builder uses the `docker` driver which fails with:

```
ERROR: Multi-platform build is not supported for the docker driver.
Switch to a different driver, or turn on the containerd image store, and try again.
```

Explicitly setting `driver: docker-container` ensures goreleaser picks up the right builder.