### PR TITLE
ci(release): enable containerd snapshotter for multi-platform docker builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,14 +24,21 @@ jobs:
           go-version-file: go.mod
           cache: true
 
+      - name: Set up Docker with containerd image store
+        uses: docker/setup-docker-action@v4
+        with:
+          daemon-config: |
+            {
+              "features": {
+                "containerd-snapshotter": true
+              }
+            }
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-        with:
-          driver: docker-container
-          install: true
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3


### PR DESCRIPTION
## Summary

- Adds `docker/setup-docker-action@v4` with `containerd-snapshotter` enabled before the buildx and QEMU steps
- Removes the now-unnecessary `driver: docker-container` / `install: true` overrides from `setup-buildx-action`

The `docker-container` buildx driver alone is not sufficient for goreleaser `dockers_v2`. The Docker daemon itself must have the containerd image store enabled (`containerd-snapshotter: true`) so it can store and push multi-platform images. Without this, the build fails with:

```
ERROR: Multi-platform build is not supported for the docker driver.
```