### PR TITLE
ci(version): add native matrix docker build to version & release workflow

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -16,11 +16,17 @@ on:
 
 permissions:
   contents: write
+  packages: write
+
+env:
+  GHCR_IMAGE: ghcr.io/${{ github.repository_owner }}/seer-cli
 
 jobs:
   release:
     name: Version & Release
     runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.version.outputs.tag }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -126,3 +132,100 @@ jobs:
             --no-input
         env:
           CLAWHUB_DISABLE_TELEMETRY: 1
+
+  docker-build:
+    name: Build Docker (${{ matrix.platform }})
+    needs: [release]
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+
+    steps:
+      - name: Prepare
+        run: |
+          platform=${{ matrix.platform }}
+          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
+
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker context for Buildx
+        run: docker context create builders
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          endpoint: builders
+          platforms: ${{ matrix.platform }}
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: ${{ matrix.platform }}
+          outputs: type=image,name=${{ env.GHCR_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ env.PLATFORM_PAIR }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  docker-merge:
+    name: Merge Docker manifests
+    runs-on: ubuntu-latest
+    needs: [release, docker-build]
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        env:
+          VERSION: ${{ needs.release.outputs.tag }}
+        run: |
+          docker buildx imagetools create \
+            -t ${{ env.GHCR_IMAGE }}:${VERSION#v} \
+            -t ${{ env.GHCR_IMAGE }}:latest \
+            $(printf '${{ env.GHCR_IMAGE }}@sha256:%s ' *)
+
+      - name: Inspect image
+        env:
+          VERSION: ${{ needs.release.outputs.tag }}
+        run: |
+          docker buildx imagetools inspect ${{ env.GHCR_IMAGE }}:${VERSION#v}


### PR DESCRIPTION
## Summary

- Adds `packages: write` permission and `GHCR_IMAGE` env to `version.yml`
- Adds `docker-build` matrix job (native `ubuntu-latest` + `ubuntu-24.04-arm` runners) that runs after the goreleaser release
- Adds `docker-merge` job that assembles the multi-arch manifest using the version tag output from the release job

## Root cause

GitHub Actions does not trigger tag-triggered workflows (`release.yml`) when a tag is pushed using `GITHUB_TOKEN` from within a workflow. So `docker-build`/`docker-merge` in `release.yml` were never executing when the release was created via `version.yml`.

The fix moves Docker build directly into `version.yml` so it runs in the same workflow run as goreleaser.