### PR TITLE
security: fix clawhub analysis findings

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -16,6 +16,9 @@ env:
   - name: SEER_API_KEY
     description: API key for authenticating with the Seer server
     required: true
+  - name: SEER_MCP_AUTH_TOKEN
+    description: Bearer token for authenticating MCP HTTP transport clients (required when running the HTTP server; omit for stdio transport)
+    required: false
 ---
 
 # seer-cli

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ COPY . .
 RUN CGO_ENABLED=0 go build -ldflags="-s -w" -o /seer-cli .
 
 # Stage 2: Final image
-FROM alpine:latest
+FROM alpine:3.21
 
 RUN apk add --no-cache ca-certificates
 

--- a/install.sh
+++ b/install.sh
@@ -58,10 +58,25 @@ echo "Installing ${BIN} ${VERSION} (${OS}/${ARCH})..."
 TMP=$(mktemp -d)
 trap 'rm -rf "$TMP"' EXIT
 
+CHECKSUMS_FILE="${BIN}_${VERSION_BARE}_checksums.txt"
+CHECKSUMS_URL="https://github.com/${REPO}/releases/download/${VERSION}/${CHECKSUMS_FILE}"
+
 if command -v curl > /dev/null 2>&1; then
   curl -fsSL "$URL" -o "${TMP}/${ARCHIVE}"
+  curl -fsSL "$CHECKSUMS_URL" -o "${TMP}/${CHECKSUMS_FILE}"
 else
   wget -qO "${TMP}/${ARCHIVE}" "$URL"
+  wget -qO "${TMP}/${CHECKSUMS_FILE}" "$CHECKSUMS_URL"
+fi
+
+# ── Verify checksum ───────────────────────────────────────────────────────────
+echo "Verifying checksum..."
+if command -v sha256sum > /dev/null 2>&1; then
+  (cd "$TMP" && grep "${ARCHIVE}" "${CHECKSUMS_FILE}" | sha256sum -c -)
+elif command -v shasum > /dev/null 2>&1; then
+  (cd "$TMP" && grep "${ARCHIVE}" "${CHECKSUMS_FILE}" | shasum -a 256 -c -)
+else
+  echo "Warning: sha256sum/shasum not found — skipping checksum verification"
 fi
 
 tar -xzf "${TMP}/${ARCHIVE}" -C "$TMP"


### PR DESCRIPTION
## Summary

- **AGENT.md**: Add `SEER_MCP_AUTH_TOKEN` to frontmatter `env` metadata (`required: false`) so the registry correctly surfaces this credential to users — previously omitted, causing a manifest/runtime mismatch
- **install.sh**: Download and verify `checksums.txt` before extracting the archive, using `sha256sum` (Linux) or `shasum -a 256` (macOS); warns if neither tool is available
- **Dockerfile**: Pin base image from `alpine:latest` to `alpine:3.21` to prevent silent base image changes

## Test plan

- [ ] Run `install.sh` on Linux and macOS and confirm "OK" checksum output before binary is placed
- [ ] Tamper with the archive in `/tmp` and confirm the script exits non-zero before installation
- [ ] Build the Docker image and confirm it uses `alpine:3.21`