### PR TITLE
chore(ci): opt into Node.js 24 for GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   test:
     name: Test

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -20,6 +20,7 @@ permissions:
 
 env:
   GHCR_IMAGE: ghcr.io/${{ github.repository_owner }}/seer-cli
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   release:
@@ -112,7 +113,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser
-          version: latest
+          version: "~> v2"
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Add `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` to both `ci.yml` and `version.yml` workflow env — this is the GitHub-recommended opt-in before the forced migration on June 2nd, 2026
- Pin GoReleaser version from `latest` to `"~> v2"` to silence the secondary warning about version resolution

## Test plan

- [ ] Trigger the CI workflow and confirm no Node.js 20 deprecation warnings appear
- [ ] Trigger the Version & Release workflow (dry-run or pre-release) and confirm no warnings