### PR TITLE
feat(mcp): add multi-tenant HTTP mode with per-user API keys

### DIFF
--- a/cmd/mcp/mcp.go
+++ b/cmd/mcp/mcp.go
@@ -12,6 +12,18 @@ import (
 // OverrideServerURL is used by tests to redirect API calls to a mock server.
 var OverrideServerURL string
 
+type contextKey string
+
+const apiKeyCtxKey contextKey = "seerApiKey"
+
+// APIKeyContextKey is exported for tests to inject a key directly.
+const APIKeyContextKey = apiKeyCtxKey
+
+func apiKeyFromContext(ctx context.Context) string {
+	v, _ := ctx.Value(apiKeyCtxKey).(string)
+	return v
+}
+
 var Cmd = &cobra.Command{
 	Use:   "mcp",
 	Short: "Run a Model Context Protocol (MCP) server exposing the Seer API",
@@ -23,20 +35,29 @@ var Cmd = &cobra.Command{
   seer-cli mcp serve --transport http --auth-token mysecret`,
 }
 
-func newAPIClient() (*api.APIClient, context.Context) {
+// newAPIClientWithKey builds a client using apiKey, falling back to Viper when empty.
+func newAPIClientWithKey(apiKey string) *api.APIClient {
 	configuration := api.NewConfiguration()
 	serverURL := viper.GetString("server")
 	if !strings.HasSuffix(serverURL, "/api/v1") {
 		serverURL = strings.TrimSuffix(serverURL, "/") + "/api/v1"
 	}
 	configuration.Servers = api.ServerConfigurations{{URL: serverURL, Description: "Configured Server"}}
-	if key := viper.GetString("api_key"); key != "" {
+	key := apiKey
+	if key == "" {
+		key = viper.GetString("api_key")
+	}
+	if key != "" {
 		configuration.AddDefaultHeader("X-Api-Key", key)
 	}
 	if OverrideServerURL != "" {
 		configuration.Servers = api.ServerConfigurations{{URL: OverrideServerURL, Description: "Mock Server"}}
 	}
-	return api.NewAPIClient(configuration), context.Background()
+	return api.NewAPIClient(configuration)
+}
+
+func newAPIClient() (*api.APIClient, context.Context) {
+	return newAPIClientWithKey(""), context.Background()
 }
 
 // NewAPIClientForTest is an exported alias used by tests.

--- a/cmd/mcp/serve.go
+++ b/cmd/mcp/serve.go
@@ -1,6 +1,7 @@
 package mcp
 
 import (
+	"context"
 	"crypto/subtle"
 	"fmt"
 	"net/http"
@@ -26,7 +27,10 @@ var serveCmd = &cobra.Command{
   seer-cli mcp serve --transport http --auth-token mysecret --tls-cert /path/to/cert.pem --tls-key /path/to/key.pem
 
   # Start over HTTP without auth (insecure, not recommended)
-  seer-cli mcp serve --transport http --no-auth`,
+  seer-cli mcp serve --transport http --no-auth
+
+  # Start in multi-tenant mode (per-user API keys in URL path)
+  seer-cli mcp serve --transport http --no-auth --multi-tenant`,
 	RunE: runServe,
 }
 
@@ -37,6 +41,7 @@ func init() {
 	serveCmd.Flags().Bool("no-auth", false, "Disable authentication (insecure — must be explicit)")
 	serveCmd.Flags().String("tls-cert", "", "Path to TLS certificate file")
 	serveCmd.Flags().String("tls-key", "", "Path to TLS private key file")
+	serveCmd.Flags().Bool("multi-tenant", false, "Route /{seer-api-token}/mcp for per-user API keys (HTTP transport only)")
 	viper.BindPFlag("mcp_auth_token", serveCmd.Flags().Lookup("auth-token"))
 	Cmd.AddCommand(serveCmd)
 }
@@ -48,30 +53,34 @@ func runServe(cmd *cobra.Command, args []string) error {
 	noAuth, _ := cmd.Flags().GetBool("no-auth")
 	tlsCert, _ := cmd.Flags().GetString("tls-cert")
 	tlsKey, _ := cmd.Flags().GetString("tls-key")
+	multiTenant, _ := cmd.Flags().GetBool("multi-tenant")
 
 	if transport == "http" && authToken == "" && !noAuth {
 		return fmt.Errorf("HTTP transport requires --auth-token or --no-auth (insecure) to be set explicitly")
 	}
 
+	if multiTenant && transport != "http" {
+		return fmt.Errorf("--multi-tenant requires --transport http")
+	}
+
 	verbose := viper.GetBool("verbose")
-	client, ctx := newAPIClient()
 
 	s := server.NewMCPServer("seer-mcp", "1.0.0")
 
-	registerStatusTools(s, client, ctx)
-	registerSearchTools(s, client, ctx)
-	registerMoviesTools(s, client, ctx)
-	registerTVTools(s, client, ctx)
-	registerRequestTools(s, client, ctx)
-	registerMediaTools(s, client, ctx)
-	registerUsersTools(s, client, ctx)
-	registerIssueTools(s, client, ctx)
-	registerPersonTools(s, client, ctx)
-	registerCollectionTools(s, client, ctx)
-	registerServiceTools(s, client, ctx)
-	registerSettingsTools(s, client, ctx)
-	registerWatchlistTools(s, client, ctx)
-	registerBlocklistTools(s, client, ctx)
+	registerStatusTools(s)
+	registerSearchTools(s)
+	registerMoviesTools(s)
+	registerTVTools(s)
+	registerRequestTools(s)
+	registerMediaTools(s)
+	registerUsersTools(s)
+	registerIssueTools(s)
+	registerPersonTools(s)
+	registerCollectionTools(s)
+	registerServiceTools(s)
+	registerSettingsTools(s)
+	registerWatchlistTools(s)
+	registerBlocklistTools(s)
 
 	switch transport {
 	case "stdio":
@@ -96,6 +105,9 @@ func runServe(cmd *cobra.Command, args []string) error {
 			host = "localhost" + host
 		}
 		endpoint := fmt.Sprintf("%s://%s/mcp", scheme, host)
+		if multiTenant {
+			endpoint = fmt.Sprintf("%s://%s/{seer-api-token}/mcp", scheme, host)
+		}
 
 		fmt.Fprintf(os.Stderr, "seer-mcp: listening on %s\n", endpoint)
 		fmt.Fprintf(os.Stderr, "\nConfigure your MCP client:\n")
@@ -113,15 +125,21 @@ func runServe(cmd *cobra.Command, args []string) error {
 			fmt.Fprintf(os.Stderr, "  Bind addr: %s\n", addr)
 			fmt.Fprintf(os.Stderr, "  TLS: %v\n", tlsCert != "")
 			fmt.Fprintf(os.Stderr, "  Auth: %v\n", authToken != "")
+			fmt.Fprintf(os.Stderr, "  Multi-tenant: %v\n", multiTenant)
 			fmt.Fprintf(os.Stderr, "  Tools registered: 43\n")
 		}
 
 		fmt.Fprintf(os.Stderr, "\n")
 
 		httpHandler := server.NewStreamableHTTPServer(s)
-		var handler http.Handler = httpHandler
+		var handler http.Handler
+		if multiTenant {
+			handler = tenantRoutingHandler(httpHandler)
+		} else {
+			handler = httpHandler
+		}
 		if authToken != "" {
-			handler = bearerAuthMiddleware(authToken, httpHandler)
+			handler = bearerAuthMiddleware(authToken, handler)
 		}
 		srv := &http.Server{
 			Addr:    addr,
@@ -150,5 +168,33 @@ func bearerAuthMiddleware(token string, next http.Handler) http.Handler {
 			return
 		}
 		next.ServeHTTP(w, r)
+	})
+}
+
+// TenantRoutingHandler extracts the Seer API token from /{token}/mcp paths and
+// injects it into the request context before forwarding to the MCP handler.
+// Exported for testing.
+func TenantRoutingHandler(mcpHandler http.Handler) http.Handler {
+	return tenantRoutingHandler(mcpHandler)
+}
+
+func tenantRoutingHandler(mcpHandler http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Expect /{token}/mcp or /{token}/mcp/...
+		path := strings.TrimPrefix(r.URL.Path, "/")
+		slash := strings.Index(path, "/")
+		if slash < 0 {
+			http.NotFound(w, r)
+			return
+		}
+		token, rest := path[:slash], path[slash:] // rest = "/mcp" or "/mcp/..."
+		if token == "" || !strings.HasPrefix(rest, "/mcp") {
+			http.NotFound(w, r)
+			return
+		}
+		ctx := context.WithValue(r.Context(), apiKeyCtxKey, token)
+		r2 := r.Clone(ctx)
+		r2.URL.Path = rest
+		mcpHandler.ServeHTTP(w, r2)
 	})
 }

--- a/cmd/mcp/tools_blocklist.go
+++ b/cmd/mcp/tools_blocklist.go
@@ -11,14 +11,14 @@ import (
 	"github.com/mark3labs/mcp-go/server"
 )
 
-func registerBlocklistTools(s *server.MCPServer, client *api.APIClient, ctx context.Context) {
+func registerBlocklistTools(s *server.MCPServer) {
 	s.AddTool(
 		mcp.NewTool("blocklist_list",
 			mcp.WithDescription("List all blocklisted media items"),
 			mcp.WithNumber("take", mcp.Description("Number of results to return")),
 			mcp.WithNumber("skip", mcp.Description("Number of results to skip")),
 		),
-		BlocklistListHandler(client, ctx),
+		BlocklistListHandler(),
 	)
 
 	s.AddTool(
@@ -27,7 +27,7 @@ func registerBlocklistTools(s *server.MCPServer, client *api.APIClient, ctx cont
 			mcp.WithNumber("tmdbId", mcp.Required(), mcp.Description("TMDB media ID")),
 			mcp.WithString("title", mcp.Description("Media title")),
 		),
-		BlocklistAddHandler(client, ctx),
+		BlocklistAddHandler(),
 	)
 
 	s.AddTool(
@@ -35,13 +35,14 @@ func registerBlocklistTools(s *server.MCPServer, client *api.APIClient, ctx cont
 			mcp.WithDescription("Remove a media item from the blocklist"),
 			mcp.WithString("tmdbId", mcp.Required(), mcp.Description("TMDB media ID")),
 		),
-		BlocklistRemoveHandler(client, ctx),
+		BlocklistRemoveHandler(),
 	)
 }
 
-func BlocklistListHandler(client *api.APIClient, ctx context.Context) server.ToolHandlerFunc {
+func BlocklistListHandler() server.ToolHandlerFunc {
 	return func(callCtx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		r := client.BlocklistAPI.BlocklistGet(ctx)
+		client := newAPIClientWithKey(apiKeyFromContext(callCtx))
+		r := client.BlocklistAPI.BlocklistGet(callCtx)
 		if take := req.GetFloat("take", 0); take > 0 {
 			r = r.Take(float32(take))
 		}
@@ -60,7 +61,7 @@ func BlocklistListHandler(client *api.APIClient, ctx context.Context) server.Too
 	}
 }
 
-func BlocklistAddHandler(client *api.APIClient, ctx context.Context) server.ToolHandlerFunc {
+func BlocklistAddHandler() server.ToolHandlerFunc {
 	return func(callCtx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		tmdbId, err := req.RequireFloat("tmdbId")
 		if err != nil {
@@ -73,7 +74,8 @@ func BlocklistAddHandler(client *api.APIClient, ctx context.Context) server.Tool
 		if title := req.GetString("title", ""); title != "" {
 			body.Title = &title
 		}
-		_, err = client.BlocklistAPI.BlocklistPost(ctx).Blocklist(body).Execute()
+		client := newAPIClientWithKey(apiKeyFromContext(callCtx))
+		_, err = client.BlocklistAPI.BlocklistPost(callCtx).Blocklist(body).Execute()
 		if err != nil {
 			return nil, fmt.Errorf("BlocklistPost failed: %w", err)
 		}
@@ -81,13 +83,14 @@ func BlocklistAddHandler(client *api.APIClient, ctx context.Context) server.Tool
 	}
 }
 
-func BlocklistRemoveHandler(client *api.APIClient, ctx context.Context) server.ToolHandlerFunc {
+func BlocklistRemoveHandler() server.ToolHandlerFunc {
 	return func(callCtx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		tmdbId, err := req.RequireString("tmdbId")
 		if err != nil {
 			return nil, err
 		}
-		_, err = client.BlocklistAPI.BlocklistTmdbIdDelete(ctx, tmdbId).Execute()
+		client := newAPIClientWithKey(apiKeyFromContext(callCtx))
+		_, err = client.BlocklistAPI.BlocklistTmdbIdDelete(callCtx, tmdbId).Execute()
 		if err != nil {
 			return nil, fmt.Errorf("BlocklistTmdbIdDelete failed: %w", err)
 		}

--- a/cmd/mcp/tools_collection.go
+++ b/cmd/mcp/tools_collection.go
@@ -7,26 +7,26 @@ import (
 
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
-	api "seer-cli/pkg/api"
 )
 
-func registerCollectionTools(s *server.MCPServer, client *api.APIClient, ctx context.Context) {
+func registerCollectionTools(s *server.MCPServer) {
 	s.AddTool(
 		mcp.NewTool("collection_get",
 			mcp.WithDescription("Get collection details by TMDB collection ID"),
 			mcp.WithNumber("collectionId", mcp.Required(), mcp.Description("TMDB collection ID")),
 		),
-		CollectionGetHandler(client, ctx),
+		CollectionGetHandler(),
 	)
 }
 
-func CollectionGetHandler(client *api.APIClient, ctx context.Context) server.ToolHandlerFunc {
+func CollectionGetHandler() server.ToolHandlerFunc {
 	return func(callCtx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		collectionId, err := req.RequireFloat("collectionId")
 		if err != nil {
 			return nil, err
 		}
-		res, _, err := client.CollectionAPI.CollectionCollectionIdGet(ctx, float32(collectionId)).Execute()
+		client := newAPIClientWithKey(apiKeyFromContext(callCtx))
+		res, _, err := client.CollectionAPI.CollectionCollectionIdGet(callCtx, float32(collectionId)).Execute()
 		if err != nil {
 			return nil, fmt.Errorf("CollectionCollectionIdGet failed: %w", err)
 		}

--- a/cmd/mcp/tools_issues.go
+++ b/cmd/mcp/tools_issues.go
@@ -10,14 +10,14 @@ import (
 	api "seer-cli/pkg/api"
 )
 
-func registerIssueTools(s *server.MCPServer, client *api.APIClient, ctx context.Context) {
+func registerIssueTools(s *server.MCPServer) {
 	s.AddTool(
 		mcp.NewTool("issue_list",
 			mcp.WithDescription("List issues"),
 			mcp.WithNumber("take", mcp.Description("Number of results to return")),
 			mcp.WithNumber("skip", mcp.Description("Number of results to skip")),
 		),
-		IssueListHandler(client, ctx),
+		IssueListHandler(),
 	)
 
 	s.AddTool(
@@ -25,7 +25,7 @@ func registerIssueTools(s *server.MCPServer, client *api.APIClient, ctx context.
 			mcp.WithDescription("Get a specific issue by ID"),
 			mcp.WithNumber("issueId", mcp.Required(), mcp.Description("Issue ID")),
 		),
-		IssueGetHandler(client, ctx),
+		IssueGetHandler(),
 	)
 
 	s.AddTool(
@@ -35,7 +35,7 @@ func registerIssueTools(s *server.MCPServer, client *api.APIClient, ctx context.
 			mcp.WithString("message", mcp.Required(), mcp.Description("Issue message")),
 			mcp.WithNumber("mediaId", mcp.Required(), mcp.Description("Media ID")),
 		),
-		IssueCreateHandler(client, ctx),
+		IssueCreateHandler(),
 	)
 
 	s.AddTool(
@@ -44,20 +44,21 @@ func registerIssueTools(s *server.MCPServer, client *api.APIClient, ctx context.
 			mcp.WithString("issueId", mcp.Required(), mcp.Description("Issue ID")),
 			mcp.WithString("status", mcp.Required(), mcp.Description("New status (open, resolved)")),
 		),
-		IssueStatusUpdateHandler(client, ctx),
+		IssueStatusUpdateHandler(),
 	)
 
 	s.AddTool(
 		mcp.NewTool("issue_count",
 			mcp.WithDescription("Get issue counts by status"),
 		),
-		IssueCountHandler(client, ctx),
+		IssueCountHandler(),
 	)
 }
 
-func IssueListHandler(client *api.APIClient, ctx context.Context) server.ToolHandlerFunc {
+func IssueListHandler() server.ToolHandlerFunc {
 	return func(callCtx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		r := client.IssueAPI.IssueGet(ctx)
+		client := newAPIClientWithKey(apiKeyFromContext(callCtx))
+		r := client.IssueAPI.IssueGet(callCtx)
 		if take := req.GetFloat("take", 0); take > 0 {
 			r = r.Take(float32(take))
 		}
@@ -76,13 +77,14 @@ func IssueListHandler(client *api.APIClient, ctx context.Context) server.ToolHan
 	}
 }
 
-func IssueGetHandler(client *api.APIClient, ctx context.Context) server.ToolHandlerFunc {
+func IssueGetHandler() server.ToolHandlerFunc {
 	return func(callCtx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		issueId, err := req.RequireFloat("issueId")
 		if err != nil {
 			return nil, err
 		}
-		res, _, err := client.IssueAPI.IssueIssueIdGet(ctx, float32(issueId)).Execute()
+		client := newAPIClientWithKey(apiKeyFromContext(callCtx))
+		res, _, err := client.IssueAPI.IssueIssueIdGet(callCtx, float32(issueId)).Execute()
 		if err != nil {
 			return nil, fmt.Errorf("IssueIssueIdGet failed: %w", err)
 		}
@@ -94,7 +96,7 @@ func IssueGetHandler(client *api.APIClient, ctx context.Context) server.ToolHand
 	}
 }
 
-func IssueCreateHandler(client *api.APIClient, ctx context.Context) server.ToolHandlerFunc {
+func IssueCreateHandler() server.ToolHandlerFunc {
 	return func(callCtx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		issueType, err := req.RequireFloat("issueType")
 		if err != nil {
@@ -115,7 +117,8 @@ func IssueCreateHandler(client *api.APIClient, ctx context.Context) server.ToolH
 			Message:   &message,
 			MediaId:   &mediaIdFloat,
 		}
-		res, _, err := client.IssueAPI.IssuePost(ctx).IssuePostRequest(body).Execute()
+		client := newAPIClientWithKey(apiKeyFromContext(callCtx))
+		res, _, err := client.IssueAPI.IssuePost(callCtx).IssuePostRequest(body).Execute()
 		if err != nil {
 			return nil, fmt.Errorf("IssuePost failed: %w", err)
 		}
@@ -127,7 +130,7 @@ func IssueCreateHandler(client *api.APIClient, ctx context.Context) server.ToolH
 	}
 }
 
-func IssueStatusUpdateHandler(client *api.APIClient, ctx context.Context) server.ToolHandlerFunc {
+func IssueStatusUpdateHandler() server.ToolHandlerFunc {
 	return func(callCtx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		issueId, err := req.RequireString("issueId")
 		if err != nil {
@@ -137,7 +140,8 @@ func IssueStatusUpdateHandler(client *api.APIClient, ctx context.Context) server
 		if err != nil {
 			return nil, err
 		}
-		res, _, err := client.IssueAPI.IssueIssueIdStatusPost(ctx, issueId, status).Execute()
+		client := newAPIClientWithKey(apiKeyFromContext(callCtx))
+		res, _, err := client.IssueAPI.IssueIssueIdStatusPost(callCtx, issueId, status).Execute()
 		if err != nil {
 			return nil, fmt.Errorf("IssueIssueIdStatusPost failed: %w", err)
 		}
@@ -149,9 +153,10 @@ func IssueStatusUpdateHandler(client *api.APIClient, ctx context.Context) server
 	}
 }
 
-func IssueCountHandler(client *api.APIClient, ctx context.Context) server.ToolHandlerFunc {
+func IssueCountHandler() server.ToolHandlerFunc {
 	return func(callCtx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		res, _, err := client.IssueAPI.IssueCountGet(ctx).Execute()
+		client := newAPIClientWithKey(apiKeyFromContext(callCtx))
+		res, _, err := client.IssueAPI.IssueCountGet(callCtx).Execute()
 		if err != nil {
 			return nil, fmt.Errorf("IssueCountGet failed: %w", err)
 		}

--- a/cmd/mcp/tools_media.go
+++ b/cmd/mcp/tools_media.go
@@ -7,10 +7,9 @@ import (
 
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
-	api "seer-cli/pkg/api"
 )
 
-func registerMediaTools(s *server.MCPServer, client *api.APIClient, ctx context.Context) {
+func registerMediaTools(s *server.MCPServer) {
 	s.AddTool(
 		mcp.NewTool("media_list",
 			mcp.WithDescription("List media items"),
@@ -19,7 +18,7 @@ func registerMediaTools(s *server.MCPServer, client *api.APIClient, ctx context.
 			mcp.WithString("filter", mcp.Description("Filter by status")),
 			mcp.WithString("sort", mcp.Description("Sort field")),
 		),
-		MediaListHandler(client, ctx),
+		MediaListHandler(),
 	)
 
 	s.AddTool(
@@ -28,13 +27,14 @@ func registerMediaTools(s *server.MCPServer, client *api.APIClient, ctx context.
 			mcp.WithString("mediaId", mcp.Required(), mcp.Description("Media ID")),
 			mcp.WithString("status", mcp.Required(), mcp.Description("New status (available, partial, processing, pending, unknown)")),
 		),
-		MediaStatusUpdateHandler(client, ctx),
+		MediaStatusUpdateHandler(),
 	)
 }
 
-func MediaListHandler(client *api.APIClient, ctx context.Context) server.ToolHandlerFunc {
+func MediaListHandler() server.ToolHandlerFunc {
 	return func(callCtx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		r := client.MediaAPI.MediaGet(ctx)
+		client := newAPIClientWithKey(apiKeyFromContext(callCtx))
+		r := client.MediaAPI.MediaGet(callCtx)
 		if take := req.GetFloat("take", 0); take > 0 {
 			r = r.Take(float32(take))
 		}
@@ -59,7 +59,7 @@ func MediaListHandler(client *api.APIClient, ctx context.Context) server.ToolHan
 	}
 }
 
-func MediaStatusUpdateHandler(client *api.APIClient, ctx context.Context) server.ToolHandlerFunc {
+func MediaStatusUpdateHandler() server.ToolHandlerFunc {
 	return func(callCtx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		mediaId, err := req.RequireString("mediaId")
 		if err != nil {
@@ -69,7 +69,8 @@ func MediaStatusUpdateHandler(client *api.APIClient, ctx context.Context) server
 		if err != nil {
 			return nil, err
 		}
-		res, _, err := client.MediaAPI.MediaMediaIdStatusPost(ctx, mediaId, status).Execute()
+		client := newAPIClientWithKey(apiKeyFromContext(callCtx))
+		res, _, err := client.MediaAPI.MediaMediaIdStatusPost(callCtx, mediaId, status).Execute()
 		if err != nil {
 			return nil, fmt.Errorf("MediaMediaIdStatusPost failed: %w", err)
 		}

--- a/cmd/mcp/tools_movies.go
+++ b/cmd/mcp/tools_movies.go
@@ -7,16 +7,15 @@ import (
 
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
-	api "seer-cli/pkg/api"
 )
 
-func registerMoviesTools(s *server.MCPServer, client *api.APIClient, ctx context.Context) {
+func registerMoviesTools(s *server.MCPServer) {
 	s.AddTool(
 		mcp.NewTool("movies_get",
 			mcp.WithDescription("Get movie details by TMDB ID"),
 			mcp.WithNumber("movieId", mcp.Required(), mcp.Description("TMDB movie ID")),
 		),
-		MoviesGetHandler(client, ctx),
+		MoviesGetHandler(),
 	)
 
 	s.AddTool(
@@ -25,7 +24,7 @@ func registerMoviesTools(s *server.MCPServer, client *api.APIClient, ctx context
 			mcp.WithNumber("movieId", mcp.Required(), mcp.Description("TMDB movie ID")),
 			mcp.WithNumber("page", mcp.Description("Page number")),
 		),
-		MoviesRecommendationsHandler(client, ctx),
+		MoviesRecommendationsHandler(),
 	)
 
 	s.AddTool(
@@ -34,7 +33,7 @@ func registerMoviesTools(s *server.MCPServer, client *api.APIClient, ctx context
 			mcp.WithNumber("movieId", mcp.Required(), mcp.Description("TMDB movie ID")),
 			mcp.WithNumber("page", mcp.Description("Page number")),
 		),
-		MoviesSimilarHandler(client, ctx),
+		MoviesSimilarHandler(),
 	)
 
 	s.AddTool(
@@ -42,17 +41,18 @@ func registerMoviesTools(s *server.MCPServer, client *api.APIClient, ctx context
 			mcp.WithDescription("Get ratings for a given movie"),
 			mcp.WithNumber("movieId", mcp.Required(), mcp.Description("TMDB movie ID")),
 		),
-		MoviesRatingsHandler(client, ctx),
+		MoviesRatingsHandler(),
 	)
 }
 
-func MoviesGetHandler(client *api.APIClient, ctx context.Context) server.ToolHandlerFunc {
+func MoviesGetHandler() server.ToolHandlerFunc {
 	return func(callCtx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		movieId, err := req.RequireFloat("movieId")
 		if err != nil {
 			return nil, err
 		}
-		res, _, err := client.MoviesAPI.MovieMovieIdGet(ctx, float32(movieId)).Execute()
+		client := newAPIClientWithKey(apiKeyFromContext(callCtx))
+		res, _, err := client.MoviesAPI.MovieMovieIdGet(callCtx, float32(movieId)).Execute()
 		if err != nil {
 			return nil, fmt.Errorf("MovieMovieIdGet failed: %w", err)
 		}
@@ -64,13 +64,14 @@ func MoviesGetHandler(client *api.APIClient, ctx context.Context) server.ToolHan
 	}
 }
 
-func MoviesRecommendationsHandler(client *api.APIClient, ctx context.Context) server.ToolHandlerFunc {
+func MoviesRecommendationsHandler() server.ToolHandlerFunc {
 	return func(callCtx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		movieId, err := req.RequireFloat("movieId")
 		if err != nil {
 			return nil, err
 		}
-		r := client.MoviesAPI.MovieMovieIdRecommendationsGet(ctx, float32(movieId))
+		client := newAPIClientWithKey(apiKeyFromContext(callCtx))
+		r := client.MoviesAPI.MovieMovieIdRecommendationsGet(callCtx, float32(movieId))
 		if page := req.GetFloat("page", 0); page > 0 {
 			r = r.Page(float32(page))
 		}
@@ -86,13 +87,14 @@ func MoviesRecommendationsHandler(client *api.APIClient, ctx context.Context) se
 	}
 }
 
-func MoviesSimilarHandler(client *api.APIClient, ctx context.Context) server.ToolHandlerFunc {
+func MoviesSimilarHandler() server.ToolHandlerFunc {
 	return func(callCtx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		movieId, err := req.RequireFloat("movieId")
 		if err != nil {
 			return nil, err
 		}
-		r := client.MoviesAPI.MovieMovieIdSimilarGet(ctx, float32(movieId))
+		client := newAPIClientWithKey(apiKeyFromContext(callCtx))
+		r := client.MoviesAPI.MovieMovieIdSimilarGet(callCtx, float32(movieId))
 		if page := req.GetFloat("page", 0); page > 0 {
 			r = r.Page(float32(page))
 		}
@@ -108,13 +110,14 @@ func MoviesSimilarHandler(client *api.APIClient, ctx context.Context) server.Too
 	}
 }
 
-func MoviesRatingsHandler(client *api.APIClient, ctx context.Context) server.ToolHandlerFunc {
+func MoviesRatingsHandler() server.ToolHandlerFunc {
 	return func(callCtx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		movieId, err := req.RequireFloat("movieId")
 		if err != nil {
 			return nil, err
 		}
-		res, _, err := client.MoviesAPI.MovieMovieIdRatingsGet(ctx, float32(movieId)).Execute()
+		client := newAPIClientWithKey(apiKeyFromContext(callCtx))
+		res, _, err := client.MoviesAPI.MovieMovieIdRatingsGet(callCtx, float32(movieId)).Execute()
 		if err != nil {
 			return nil, fmt.Errorf("MovieMovieIdRatingsGet failed: %w", err)
 		}

--- a/cmd/mcp/tools_person.go
+++ b/cmd/mcp/tools_person.go
@@ -7,16 +7,15 @@ import (
 
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
-	api "seer-cli/pkg/api"
 )
 
-func registerPersonTools(s *server.MCPServer, client *api.APIClient, ctx context.Context) {
+func registerPersonTools(s *server.MCPServer) {
 	s.AddTool(
 		mcp.NewTool("person_get",
 			mcp.WithDescription("Get person details by TMDB ID"),
 			mcp.WithNumber("personId", mcp.Required(), mcp.Description("TMDB person ID")),
 		),
-		PersonGetHandler(client, ctx),
+		PersonGetHandler(),
 	)
 
 	s.AddTool(
@@ -24,17 +23,18 @@ func registerPersonTools(s *server.MCPServer, client *api.APIClient, ctx context
 			mcp.WithDescription("Get combined credits for a person"),
 			mcp.WithNumber("personId", mcp.Required(), mcp.Description("TMDB person ID")),
 		),
-		PersonCreditsHandler(client, ctx),
+		PersonCreditsHandler(),
 	)
 }
 
-func PersonGetHandler(client *api.APIClient, ctx context.Context) server.ToolHandlerFunc {
+func PersonGetHandler() server.ToolHandlerFunc {
 	return func(callCtx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		personId, err := req.RequireFloat("personId")
 		if err != nil {
 			return nil, err
 		}
-		res, _, err := client.PersonAPI.PersonPersonIdGet(ctx, float32(personId)).Execute()
+		client := newAPIClientWithKey(apiKeyFromContext(callCtx))
+		res, _, err := client.PersonAPI.PersonPersonIdGet(callCtx, float32(personId)).Execute()
 		if err != nil {
 			return nil, fmt.Errorf("PersonPersonIdGet failed: %w", err)
 		}
@@ -46,13 +46,14 @@ func PersonGetHandler(client *api.APIClient, ctx context.Context) server.ToolHan
 	}
 }
 
-func PersonCreditsHandler(client *api.APIClient, ctx context.Context) server.ToolHandlerFunc {
+func PersonCreditsHandler() server.ToolHandlerFunc {
 	return func(callCtx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		personId, err := req.RequireFloat("personId")
 		if err != nil {
 			return nil, err
 		}
-		res, _, err := client.PersonAPI.PersonPersonIdCombinedCreditsGet(ctx, float32(personId)).Execute()
+		client := newAPIClientWithKey(apiKeyFromContext(callCtx))
+		res, _, err := client.PersonAPI.PersonPersonIdCombinedCreditsGet(callCtx, float32(personId)).Execute()
 		if err != nil {
 			return nil, fmt.Errorf("PersonPersonIdCombinedCreditsGet failed: %w", err)
 		}

--- a/cmd/mcp/tools_request.go
+++ b/cmd/mcp/tools_request.go
@@ -10,7 +10,7 @@ import (
 	api "seer-cli/pkg/api"
 )
 
-func registerRequestTools(s *server.MCPServer, client *api.APIClient, ctx context.Context) {
+func registerRequestTools(s *server.MCPServer) {
 	s.AddTool(
 		mcp.NewTool("request_list",
 			mcp.WithDescription("List media requests"),
@@ -19,7 +19,7 @@ func registerRequestTools(s *server.MCPServer, client *api.APIClient, ctx contex
 			mcp.WithString("filter", mcp.Description("Filter by status (all, approved, available, pending, processing, unavailable, failed)")),
 			mcp.WithString("sort", mcp.Description("Sort field")),
 		),
-		RequestListHandler(client, ctx),
+		RequestListHandler(),
 	)
 
 	s.AddTool(
@@ -27,7 +27,7 @@ func registerRequestTools(s *server.MCPServer, client *api.APIClient, ctx contex
 			mcp.WithDescription("Get a specific media request by ID"),
 			mcp.WithString("requestId", mcp.Required(), mcp.Description("Request ID")),
 		),
-		RequestGetHandler(client, ctx),
+		RequestGetHandler(),
 	)
 
 	s.AddTool(
@@ -37,7 +37,7 @@ func registerRequestTools(s *server.MCPServer, client *api.APIClient, ctx contex
 			mcp.WithNumber("mediaId", mcp.Required(), mcp.Description("TMDB media ID")),
 			mcp.WithBoolean("is4k", mcp.Description("Request 4K version")),
 		),
-		RequestCreateHandler(client, ctx),
+		RequestCreateHandler(),
 	)
 
 	s.AddTool(
@@ -45,7 +45,7 @@ func registerRequestTools(s *server.MCPServer, client *api.APIClient, ctx contex
 			mcp.WithDescription("Approve a media request"),
 			mcp.WithString("requestId", mcp.Required(), mcp.Description("Request ID")),
 		),
-		RequestApproveHandler(client, ctx),
+		RequestApproveHandler(),
 	)
 
 	s.AddTool(
@@ -53,7 +53,7 @@ func registerRequestTools(s *server.MCPServer, client *api.APIClient, ctx contex
 			mcp.WithDescription("Decline a media request"),
 			mcp.WithString("requestId", mcp.Required(), mcp.Description("Request ID")),
 		),
-		RequestDeclineHandler(client, ctx),
+		RequestDeclineHandler(),
 	)
 
 	s.AddTool(
@@ -61,20 +61,21 @@ func registerRequestTools(s *server.MCPServer, client *api.APIClient, ctx contex
 			mcp.WithDescription("Delete a media request"),
 			mcp.WithString("requestId", mcp.Required(), mcp.Description("Request ID")),
 		),
-		RequestDeleteHandler(client, ctx),
+		RequestDeleteHandler(),
 	)
 
 	s.AddTool(
 		mcp.NewTool("request_count",
 			mcp.WithDescription("Get request counts by status"),
 		),
-		RequestCountHandler(client, ctx),
+		RequestCountHandler(),
 	)
 }
 
-func RequestListHandler(client *api.APIClient, ctx context.Context) server.ToolHandlerFunc {
+func RequestListHandler() server.ToolHandlerFunc {
 	return func(callCtx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		r := client.RequestAPI.RequestGet(ctx)
+		client := newAPIClientWithKey(apiKeyFromContext(callCtx))
+		r := client.RequestAPI.RequestGet(callCtx)
 		if take := req.GetFloat("take", 0); take > 0 {
 			r = r.Take(float32(take))
 		}
@@ -99,13 +100,14 @@ func RequestListHandler(client *api.APIClient, ctx context.Context) server.ToolH
 	}
 }
 
-func RequestGetHandler(client *api.APIClient, ctx context.Context) server.ToolHandlerFunc {
+func RequestGetHandler() server.ToolHandlerFunc {
 	return func(callCtx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		requestId, err := req.RequireString("requestId")
 		if err != nil {
 			return nil, err
 		}
-		res, _, err := client.RequestAPI.RequestRequestIdGet(ctx, requestId).Execute()
+		client := newAPIClientWithKey(apiKeyFromContext(callCtx))
+		res, _, err := client.RequestAPI.RequestRequestIdGet(callCtx, requestId).Execute()
 		if err != nil {
 			return nil, fmt.Errorf("RequestRequestIdGet failed: %w", err)
 		}
@@ -117,7 +119,7 @@ func RequestGetHandler(client *api.APIClient, ctx context.Context) server.ToolHa
 	}
 }
 
-func RequestCreateHandler(client *api.APIClient, ctx context.Context) server.ToolHandlerFunc {
+func RequestCreateHandler() server.ToolHandlerFunc {
 	return func(callCtx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		mediaType, err := req.RequireString("mediaType")
 		if err != nil {
@@ -131,7 +133,8 @@ func RequestCreateHandler(client *api.APIClient, ctx context.Context) server.Too
 		if is4k := req.GetBool("is4k", false); is4k {
 			body.Is4k = &is4k
 		}
-		res, _, err := client.RequestAPI.RequestPost(ctx).RequestPostRequest(*body).Execute()
+		client := newAPIClientWithKey(apiKeyFromContext(callCtx))
+		res, _, err := client.RequestAPI.RequestPost(callCtx).RequestPostRequest(*body).Execute()
 		if err != nil {
 			return nil, fmt.Errorf("RequestPost failed: %w", err)
 		}
@@ -143,13 +146,14 @@ func RequestCreateHandler(client *api.APIClient, ctx context.Context) server.Too
 	}
 }
 
-func RequestApproveHandler(client *api.APIClient, ctx context.Context) server.ToolHandlerFunc {
+func RequestApproveHandler() server.ToolHandlerFunc {
 	return func(callCtx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		requestId, err := req.RequireString("requestId")
 		if err != nil {
 			return nil, err
 		}
-		res, _, err := client.RequestAPI.RequestRequestIdStatusPost(ctx, requestId, "approve").Execute()
+		client := newAPIClientWithKey(apiKeyFromContext(callCtx))
+		res, _, err := client.RequestAPI.RequestRequestIdStatusPost(callCtx, requestId, "approve").Execute()
 		if err != nil {
 			return nil, fmt.Errorf("RequestRequestIdStatusPost(approve) failed: %w", err)
 		}
@@ -161,13 +165,14 @@ func RequestApproveHandler(client *api.APIClient, ctx context.Context) server.To
 	}
 }
 
-func RequestDeclineHandler(client *api.APIClient, ctx context.Context) server.ToolHandlerFunc {
+func RequestDeclineHandler() server.ToolHandlerFunc {
 	return func(callCtx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		requestId, err := req.RequireString("requestId")
 		if err != nil {
 			return nil, err
 		}
-		res, _, err := client.RequestAPI.RequestRequestIdStatusPost(ctx, requestId, "decline").Execute()
+		client := newAPIClientWithKey(apiKeyFromContext(callCtx))
+		res, _, err := client.RequestAPI.RequestRequestIdStatusPost(callCtx, requestId, "decline").Execute()
 		if err != nil {
 			return nil, fmt.Errorf("RequestRequestIdStatusPost(decline) failed: %w", err)
 		}
@@ -179,13 +184,14 @@ func RequestDeclineHandler(client *api.APIClient, ctx context.Context) server.To
 	}
 }
 
-func RequestDeleteHandler(client *api.APIClient, ctx context.Context) server.ToolHandlerFunc {
+func RequestDeleteHandler() server.ToolHandlerFunc {
 	return func(callCtx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		requestId, err := req.RequireString("requestId")
 		if err != nil {
 			return nil, err
 		}
-		_, err = client.RequestAPI.RequestRequestIdDelete(ctx, requestId).Execute()
+		client := newAPIClientWithKey(apiKeyFromContext(callCtx))
+		_, err = client.RequestAPI.RequestRequestIdDelete(callCtx, requestId).Execute()
 		if err != nil {
 			return nil, fmt.Errorf("RequestRequestIdDelete failed: %w", err)
 		}
@@ -193,9 +199,10 @@ func RequestDeleteHandler(client *api.APIClient, ctx context.Context) server.Too
 	}
 }
 
-func RequestCountHandler(client *api.APIClient, ctx context.Context) server.ToolHandlerFunc {
+func RequestCountHandler() server.ToolHandlerFunc {
 	return func(callCtx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		res, _, err := client.RequestAPI.RequestCountGet(ctx).Execute()
+		client := newAPIClientWithKey(apiKeyFromContext(callCtx))
+		res, _, err := client.RequestAPI.RequestCountGet(callCtx).Execute()
 		if err != nil {
 			return nil, fmt.Errorf("RequestCountGet failed: %w", err)
 		}

--- a/cmd/mcp/tools_search.go
+++ b/cmd/mcp/tools_search.go
@@ -7,17 +7,16 @@ import (
 
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
-	api "seer-cli/pkg/api"
 )
 
-func registerSearchTools(s *server.MCPServer, client *api.APIClient, ctx context.Context) {
+func registerSearchTools(s *server.MCPServer) {
 	s.AddTool(
 		mcp.NewTool("search_multi",
 			mcp.WithDescription("Search for movies, TV shows, and people"),
 			mcp.WithString("query", mcp.Required(), mcp.Description("Search query")),
 			mcp.WithNumber("page", mcp.Description("Page number")),
 		),
-		SearchMultiHandler(client, ctx),
+		SearchMultiHandler(),
 	)
 
 	s.AddTool(
@@ -25,7 +24,7 @@ func registerSearchTools(s *server.MCPServer, client *api.APIClient, ctx context
 			mcp.WithDescription("Discover movies"),
 			mcp.WithNumber("page", mcp.Description("Page number")),
 		),
-		SearchDiscoverMoviesHandler(client, ctx),
+		SearchDiscoverMoviesHandler(),
 	)
 
 	s.AddTool(
@@ -33,7 +32,7 @@ func registerSearchTools(s *server.MCPServer, client *api.APIClient, ctx context
 			mcp.WithDescription("Discover TV shows"),
 			mcp.WithNumber("page", mcp.Description("Page number")),
 		),
-		SearchDiscoverTVHandler(client, ctx),
+		SearchDiscoverTVHandler(),
 	)
 
 	s.AddTool(
@@ -41,17 +40,18 @@ func registerSearchTools(s *server.MCPServer, client *api.APIClient, ctx context
 			mcp.WithDescription("Get trending movies and TV shows"),
 			mcp.WithNumber("page", mcp.Description("Page number")),
 		),
-		SearchTrendingHandler(client, ctx),
+		SearchTrendingHandler(),
 	)
 }
 
-func SearchMultiHandler(client *api.APIClient, ctx context.Context) server.ToolHandlerFunc {
+func SearchMultiHandler() server.ToolHandlerFunc {
 	return func(callCtx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		query := req.GetString("query", "")
 		if query == "" {
 			return nil, fmt.Errorf("query is required")
 		}
-		r := client.SearchAPI.SearchGet(ctx).Query(query)
+		client := newAPIClientWithKey(apiKeyFromContext(callCtx))
+		r := client.SearchAPI.SearchGet(callCtx).Query(query)
 		if page := req.GetFloat("page", 0); page > 0 {
 			r = r.Page(float32(page))
 		}
@@ -67,9 +67,10 @@ func SearchMultiHandler(client *api.APIClient, ctx context.Context) server.ToolH
 	}
 }
 
-func SearchDiscoverMoviesHandler(client *api.APIClient, ctx context.Context) server.ToolHandlerFunc {
+func SearchDiscoverMoviesHandler() server.ToolHandlerFunc {
 	return func(callCtx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		r := client.SearchAPI.DiscoverMoviesGet(ctx)
+		client := newAPIClientWithKey(apiKeyFromContext(callCtx))
+		r := client.SearchAPI.DiscoverMoviesGet(callCtx)
 		if page := req.GetFloat("page", 0); page > 0 {
 			r = r.Page(float32(page))
 		}
@@ -85,9 +86,10 @@ func SearchDiscoverMoviesHandler(client *api.APIClient, ctx context.Context) ser
 	}
 }
 
-func SearchDiscoverTVHandler(client *api.APIClient, ctx context.Context) server.ToolHandlerFunc {
+func SearchDiscoverTVHandler() server.ToolHandlerFunc {
 	return func(callCtx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		r := client.SearchAPI.DiscoverTvGet(ctx)
+		client := newAPIClientWithKey(apiKeyFromContext(callCtx))
+		r := client.SearchAPI.DiscoverTvGet(callCtx)
 		if page := req.GetFloat("page", 0); page > 0 {
 			r = r.Page(float32(page))
 		}
@@ -103,9 +105,10 @@ func SearchDiscoverTVHandler(client *api.APIClient, ctx context.Context) server.
 	}
 }
 
-func SearchTrendingHandler(client *api.APIClient, ctx context.Context) server.ToolHandlerFunc {
+func SearchTrendingHandler() server.ToolHandlerFunc {
 	return func(callCtx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		r := client.SearchAPI.DiscoverTrendingGet(ctx)
+		client := newAPIClientWithKey(apiKeyFromContext(callCtx))
+		r := client.SearchAPI.DiscoverTrendingGet(callCtx)
 		if page := req.GetFloat("page", 0); page > 0 {
 			r = r.Page(float32(page))
 		}

--- a/cmd/mcp/tools_service.go
+++ b/cmd/mcp/tools_service.go
@@ -7,28 +7,28 @@ import (
 
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
-	api "seer-cli/pkg/api"
 )
 
-func registerServiceTools(s *server.MCPServer, client *api.APIClient, ctx context.Context) {
+func registerServiceTools(s *server.MCPServer) {
 	s.AddTool(
 		mcp.NewTool("service_radarr_list",
 			mcp.WithDescription("List configured Radarr instances"),
 		),
-		ServiceRadarrListHandler(client, ctx),
+		ServiceRadarrListHandler(),
 	)
 
 	s.AddTool(
 		mcp.NewTool("service_sonarr_list",
 			mcp.WithDescription("List configured Sonarr instances"),
 		),
-		ServiceSonarrListHandler(client, ctx),
+		ServiceSonarrListHandler(),
 	)
 }
 
-func ServiceRadarrListHandler(client *api.APIClient, ctx context.Context) server.ToolHandlerFunc {
+func ServiceRadarrListHandler() server.ToolHandlerFunc {
 	return func(callCtx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		res, _, err := client.ServiceAPI.ServiceRadarrGet(ctx).Execute()
+		client := newAPIClientWithKey(apiKeyFromContext(callCtx))
+		res, _, err := client.ServiceAPI.ServiceRadarrGet(callCtx).Execute()
 		if err != nil {
 			return nil, fmt.Errorf("ServiceRadarrGet failed: %w", err)
 		}
@@ -40,9 +40,10 @@ func ServiceRadarrListHandler(client *api.APIClient, ctx context.Context) server
 	}
 }
 
-func ServiceSonarrListHandler(client *api.APIClient, ctx context.Context) server.ToolHandlerFunc {
+func ServiceSonarrListHandler() server.ToolHandlerFunc {
 	return func(callCtx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		res, _, err := client.ServiceAPI.ServiceSonarrGet(ctx).Execute()
+		client := newAPIClientWithKey(apiKeyFromContext(callCtx))
+		res, _, err := client.ServiceAPI.ServiceSonarrGet(callCtx).Execute()
 		if err != nil {
 			return nil, fmt.Errorf("ServiceSonarrGet failed: %w", err)
 		}

--- a/cmd/mcp/tools_settings.go
+++ b/cmd/mcp/tools_settings.go
@@ -7,22 +7,21 @@ import (
 
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
-	api "seer-cli/pkg/api"
 )
 
-func registerSettingsTools(s *server.MCPServer, client *api.APIClient, ctx context.Context) {
+func registerSettingsTools(s *server.MCPServer) {
 	s.AddTool(
 		mcp.NewTool("settings_about",
 			mcp.WithDescription("Get Seer system information and settings"),
 		),
-		SettingsAboutHandler(client, ctx),
+		SettingsAboutHandler(),
 	)
 
 	s.AddTool(
 		mcp.NewTool("settings_jobs_list",
 			mcp.WithDescription("List all scheduled jobs"),
 		),
-		SettingsJobsListHandler(client, ctx),
+		SettingsJobsListHandler(),
 	)
 
 	s.AddTool(
@@ -30,13 +29,14 @@ func registerSettingsTools(s *server.MCPServer, client *api.APIClient, ctx conte
 			mcp.WithDescription("Trigger a scheduled job to run immediately"),
 			mcp.WithString("jobId", mcp.Required(), mcp.Description("Job ID")),
 		),
-		SettingsJobsRunHandler(client, ctx),
+		SettingsJobsRunHandler(),
 	)
 }
 
-func SettingsAboutHandler(client *api.APIClient, ctx context.Context) server.ToolHandlerFunc {
+func SettingsAboutHandler() server.ToolHandlerFunc {
 	return func(callCtx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		res, _, err := client.SettingsAPI.SettingsAboutGet(ctx).Execute()
+		client := newAPIClientWithKey(apiKeyFromContext(callCtx))
+		res, _, err := client.SettingsAPI.SettingsAboutGet(callCtx).Execute()
 		if err != nil {
 			return nil, fmt.Errorf("SettingsAboutGet failed: %w", err)
 		}
@@ -48,9 +48,10 @@ func SettingsAboutHandler(client *api.APIClient, ctx context.Context) server.Too
 	}
 }
 
-func SettingsJobsListHandler(client *api.APIClient, ctx context.Context) server.ToolHandlerFunc {
+func SettingsJobsListHandler() server.ToolHandlerFunc {
 	return func(callCtx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		res, _, err := client.SettingsAPI.SettingsJobsGet(ctx).Execute()
+		client := newAPIClientWithKey(apiKeyFromContext(callCtx))
+		res, _, err := client.SettingsAPI.SettingsJobsGet(callCtx).Execute()
 		if err != nil {
 			return nil, fmt.Errorf("SettingsJobsGet failed: %w", err)
 		}
@@ -62,13 +63,14 @@ func SettingsJobsListHandler(client *api.APIClient, ctx context.Context) server.
 	}
 }
 
-func SettingsJobsRunHandler(client *api.APIClient, ctx context.Context) server.ToolHandlerFunc {
+func SettingsJobsRunHandler() server.ToolHandlerFunc {
 	return func(callCtx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		jobId, err := req.RequireString("jobId")
 		if err != nil {
 			return nil, err
 		}
-		res, _, err := client.SettingsAPI.SettingsJobsJobIdRunPost(ctx, jobId).Execute()
+		client := newAPIClientWithKey(apiKeyFromContext(callCtx))
+		res, _, err := client.SettingsAPI.SettingsJobsJobIdRunPost(callCtx, jobId).Execute()
 		if err != nil {
 			return nil, fmt.Errorf("SettingsJobsJobIdRunPost failed: %w", err)
 		}

--- a/cmd/mcp/tools_status.go
+++ b/cmd/mcp/tools_status.go
@@ -7,21 +7,21 @@ import (
 
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
-	api "seer-cli/pkg/api"
 )
 
-func registerStatusTools(s *server.MCPServer, client *api.APIClient, ctx context.Context) {
+func registerStatusTools(s *server.MCPServer) {
 	s.AddTool(
 		mcp.NewTool("status_system",
 			mcp.WithDescription("Get the system status of the Seer API"),
 		),
-		StatusSystemHandler(client, ctx),
+		StatusSystemHandler(),
 	)
 }
 
-func StatusSystemHandler(client *api.APIClient, ctx context.Context) server.ToolHandlerFunc {
+func StatusSystemHandler() server.ToolHandlerFunc {
 	return func(callCtx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		res, _, err := client.PublicAPI.StatusGet(ctx).Execute()
+		client := newAPIClientWithKey(apiKeyFromContext(callCtx))
+		res, _, err := client.PublicAPI.StatusGet(callCtx).Execute()
 		if err != nil {
 			return nil, fmt.Errorf("StatusGet failed: %w", err)
 		}

--- a/cmd/mcp/tools_tv.go
+++ b/cmd/mcp/tools_tv.go
@@ -7,16 +7,15 @@ import (
 
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
-	api "seer-cli/pkg/api"
 )
 
-func registerTVTools(s *server.MCPServer, client *api.APIClient, ctx context.Context) {
+func registerTVTools(s *server.MCPServer) {
 	s.AddTool(
 		mcp.NewTool("tv_get",
 			mcp.WithDescription("Get TV show details by TMDB ID"),
 			mcp.WithNumber("tvId", mcp.Required(), mcp.Description("TMDB TV show ID")),
 		),
-		TVGetHandler(client, ctx),
+		TVGetHandler(),
 	)
 
 	s.AddTool(
@@ -25,7 +24,7 @@ func registerTVTools(s *server.MCPServer, client *api.APIClient, ctx context.Con
 			mcp.WithNumber("tvId", mcp.Required(), mcp.Description("TMDB TV show ID")),
 			mcp.WithNumber("seasonNumber", mcp.Required(), mcp.Description("Season number")),
 		),
-		TVSeasonHandler(client, ctx),
+		TVSeasonHandler(),
 	)
 
 	s.AddTool(
@@ -34,7 +33,7 @@ func registerTVTools(s *server.MCPServer, client *api.APIClient, ctx context.Con
 			mcp.WithNumber("tvId", mcp.Required(), mcp.Description("TMDB TV show ID")),
 			mcp.WithNumber("page", mcp.Description("Page number")),
 		),
-		TVRecommendationsHandler(client, ctx),
+		TVRecommendationsHandler(),
 	)
 
 	s.AddTool(
@@ -43,7 +42,7 @@ func registerTVTools(s *server.MCPServer, client *api.APIClient, ctx context.Con
 			mcp.WithNumber("tvId", mcp.Required(), mcp.Description("TMDB TV show ID")),
 			mcp.WithNumber("page", mcp.Description("Page number")),
 		),
-		TVSimilarHandler(client, ctx),
+		TVSimilarHandler(),
 	)
 
 	s.AddTool(
@@ -51,17 +50,18 @@ func registerTVTools(s *server.MCPServer, client *api.APIClient, ctx context.Con
 			mcp.WithDescription("Get ratings for a given TV show"),
 			mcp.WithNumber("tvId", mcp.Required(), mcp.Description("TMDB TV show ID")),
 		),
-		TVRatingsHandler(client, ctx),
+		TVRatingsHandler(),
 	)
 }
 
-func TVGetHandler(client *api.APIClient, ctx context.Context) server.ToolHandlerFunc {
+func TVGetHandler() server.ToolHandlerFunc {
 	return func(callCtx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		tvId, err := req.RequireFloat("tvId")
 		if err != nil {
 			return nil, err
 		}
-		res, _, err := client.TvAPI.TvTvIdGet(ctx, float32(tvId)).Execute()
+		client := newAPIClientWithKey(apiKeyFromContext(callCtx))
+		res, _, err := client.TvAPI.TvTvIdGet(callCtx, float32(tvId)).Execute()
 		if err != nil {
 			return nil, fmt.Errorf("TvTvIdGet failed: %w", err)
 		}
@@ -73,7 +73,7 @@ func TVGetHandler(client *api.APIClient, ctx context.Context) server.ToolHandler
 	}
 }
 
-func TVSeasonHandler(client *api.APIClient, ctx context.Context) server.ToolHandlerFunc {
+func TVSeasonHandler() server.ToolHandlerFunc {
 	return func(callCtx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		tvId, err := req.RequireFloat("tvId")
 		if err != nil {
@@ -83,7 +83,8 @@ func TVSeasonHandler(client *api.APIClient, ctx context.Context) server.ToolHand
 		if err != nil {
 			return nil, err
 		}
-		res, _, err := client.TvAPI.TvTvIdSeasonSeasonNumberGet(ctx, float32(tvId), float32(seasonNumber)).Execute()
+		client := newAPIClientWithKey(apiKeyFromContext(callCtx))
+		res, _, err := client.TvAPI.TvTvIdSeasonSeasonNumberGet(callCtx, float32(tvId), float32(seasonNumber)).Execute()
 		if err != nil {
 			return nil, fmt.Errorf("TvTvIdSeasonSeasonNumberGet failed: %w", err)
 		}
@@ -95,13 +96,14 @@ func TVSeasonHandler(client *api.APIClient, ctx context.Context) server.ToolHand
 	}
 }
 
-func TVRecommendationsHandler(client *api.APIClient, ctx context.Context) server.ToolHandlerFunc {
+func TVRecommendationsHandler() server.ToolHandlerFunc {
 	return func(callCtx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		tvId, err := req.RequireFloat("tvId")
 		if err != nil {
 			return nil, err
 		}
-		r := client.TvAPI.TvTvIdRecommendationsGet(ctx, float32(tvId))
+		client := newAPIClientWithKey(apiKeyFromContext(callCtx))
+		r := client.TvAPI.TvTvIdRecommendationsGet(callCtx, float32(tvId))
 		if page := req.GetFloat("page", 0); page > 0 {
 			r = r.Page(float32(page))
 		}
@@ -117,13 +119,14 @@ func TVRecommendationsHandler(client *api.APIClient, ctx context.Context) server
 	}
 }
 
-func TVSimilarHandler(client *api.APIClient, ctx context.Context) server.ToolHandlerFunc {
+func TVSimilarHandler() server.ToolHandlerFunc {
 	return func(callCtx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		tvId, err := req.RequireFloat("tvId")
 		if err != nil {
 			return nil, err
 		}
-		r := client.TvAPI.TvTvIdSimilarGet(ctx, float32(tvId))
+		client := newAPIClientWithKey(apiKeyFromContext(callCtx))
+		r := client.TvAPI.TvTvIdSimilarGet(callCtx, float32(tvId))
 		if page := req.GetFloat("page", 0); page > 0 {
 			r = r.Page(float32(page))
 		}
@@ -139,13 +142,14 @@ func TVSimilarHandler(client *api.APIClient, ctx context.Context) server.ToolHan
 	}
 }
 
-func TVRatingsHandler(client *api.APIClient, ctx context.Context) server.ToolHandlerFunc {
+func TVRatingsHandler() server.ToolHandlerFunc {
 	return func(callCtx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		tvId, err := req.RequireFloat("tvId")
 		if err != nil {
 			return nil, err
 		}
-		res, _, err := client.TvAPI.TvTvIdRatingsGet(ctx, float32(tvId)).Execute()
+		client := newAPIClientWithKey(apiKeyFromContext(callCtx))
+		res, _, err := client.TvAPI.TvTvIdRatingsGet(callCtx, float32(tvId)).Execute()
 		if err != nil {
 			return nil, fmt.Errorf("TvTvIdRatingsGet failed: %w", err)
 		}

--- a/cmd/mcp/tools_users.go
+++ b/cmd/mcp/tools_users.go
@@ -7,17 +7,16 @@ import (
 
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
-	api "seer-cli/pkg/api"
 )
 
-func registerUsersTools(s *server.MCPServer, client *api.APIClient, ctx context.Context) {
+func registerUsersTools(s *server.MCPServer) {
 	s.AddTool(
 		mcp.NewTool("users_list",
 			mcp.WithDescription("List all users"),
 			mcp.WithNumber("take", mcp.Description("Number of results to return")),
 			mcp.WithNumber("skip", mcp.Description("Number of results to skip")),
 		),
-		UsersListHandler(client, ctx),
+		UsersListHandler(),
 	)
 
 	s.AddTool(
@@ -25,7 +24,7 @@ func registerUsersTools(s *server.MCPServer, client *api.APIClient, ctx context.
 			mcp.WithDescription("Get a specific user by ID"),
 			mcp.WithNumber("userId", mcp.Required(), mcp.Description("User ID")),
 		),
-		UsersGetHandler(client, ctx),
+		UsersGetHandler(),
 	)
 
 	s.AddTool(
@@ -33,13 +32,14 @@ func registerUsersTools(s *server.MCPServer, client *api.APIClient, ctx context.
 			mcp.WithDescription("Get request quota for a specific user"),
 			mcp.WithNumber("userId", mcp.Required(), mcp.Description("User ID")),
 		),
-		UsersQuotaHandler(client, ctx),
+		UsersQuotaHandler(),
 	)
 }
 
-func UsersListHandler(client *api.APIClient, ctx context.Context) server.ToolHandlerFunc {
+func UsersListHandler() server.ToolHandlerFunc {
 	return func(callCtx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		r := client.UsersAPI.UserGet(ctx)
+		client := newAPIClientWithKey(apiKeyFromContext(callCtx))
+		r := client.UsersAPI.UserGet(callCtx)
 		if take := req.GetFloat("take", 0); take > 0 {
 			r = r.Take(float32(take))
 		}
@@ -58,13 +58,14 @@ func UsersListHandler(client *api.APIClient, ctx context.Context) server.ToolHan
 	}
 }
 
-func UsersGetHandler(client *api.APIClient, ctx context.Context) server.ToolHandlerFunc {
+func UsersGetHandler() server.ToolHandlerFunc {
 	return func(callCtx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		userId, err := req.RequireFloat("userId")
 		if err != nil {
 			return nil, err
 		}
-		res, _, err := client.UsersAPI.UserUserIdGet(ctx, float32(userId)).Execute()
+		client := newAPIClientWithKey(apiKeyFromContext(callCtx))
+		res, _, err := client.UsersAPI.UserUserIdGet(callCtx, float32(userId)).Execute()
 		if err != nil {
 			return nil, fmt.Errorf("UserUserIdGet failed: %w", err)
 		}
@@ -76,13 +77,14 @@ func UsersGetHandler(client *api.APIClient, ctx context.Context) server.ToolHand
 	}
 }
 
-func UsersQuotaHandler(client *api.APIClient, ctx context.Context) server.ToolHandlerFunc {
+func UsersQuotaHandler() server.ToolHandlerFunc {
 	return func(callCtx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		userId, err := req.RequireFloat("userId")
 		if err != nil {
 			return nil, err
 		}
-		res, _, err := client.UsersAPI.UserUserIdQuotaGet(ctx, float32(userId)).Execute()
+		client := newAPIClientWithKey(apiKeyFromContext(callCtx))
+		res, _, err := client.UsersAPI.UserUserIdQuotaGet(callCtx, float32(userId)).Execute()
 		if err != nil {
 			return nil, fmt.Errorf("UserUserIdQuotaGet failed: %w", err)
 		}

--- a/cmd/mcp/tools_watchlist.go
+++ b/cmd/mcp/tools_watchlist.go
@@ -10,7 +10,7 @@ import (
 	api "seer-cli/pkg/api"
 )
 
-func registerWatchlistTools(s *server.MCPServer, client *api.APIClient, ctx context.Context) {
+func registerWatchlistTools(s *server.MCPServer) {
 	s.AddTool(
 		mcp.NewTool("watchlist_add",
 			mcp.WithDescription("Add a media item to the watchlist"),
@@ -18,7 +18,7 @@ func registerWatchlistTools(s *server.MCPServer, client *api.APIClient, ctx cont
 			mcp.WithString("title", mcp.Required(), mcp.Description("Media title")),
 			mcp.WithString("mediaType", mcp.Required(), mcp.Description("Media type: movie or tv")),
 		),
-		WatchlistAddHandler(client, ctx),
+		WatchlistAddHandler(),
 	)
 
 	s.AddTool(
@@ -26,11 +26,11 @@ func registerWatchlistTools(s *server.MCPServer, client *api.APIClient, ctx cont
 			mcp.WithDescription("Remove a media item from the watchlist"),
 			mcp.WithString("tmdbId", mcp.Required(), mcp.Description("TMDB media ID")),
 		),
-		WatchlistRemoveHandler(client, ctx),
+		WatchlistRemoveHandler(),
 	)
 }
 
-func WatchlistAddHandler(client *api.APIClient, ctx context.Context) server.ToolHandlerFunc {
+func WatchlistAddHandler() server.ToolHandlerFunc {
 	return func(callCtx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		tmdbId, err := req.RequireFloat("tmdbId")
 		if err != nil {
@@ -50,7 +50,8 @@ func WatchlistAddHandler(client *api.APIClient, ctx context.Context) server.Tool
 			Title:  &title,
 			Type:   &mediaType,
 		}
-		res, _, err := client.WatchlistAPI.WatchlistPost(ctx).Watchlist(body).Execute()
+		client := newAPIClientWithKey(apiKeyFromContext(callCtx))
+		res, _, err := client.WatchlistAPI.WatchlistPost(callCtx).Watchlist(body).Execute()
 		if err != nil {
 			return nil, fmt.Errorf("WatchlistPost failed: %w", err)
 		}
@@ -62,13 +63,14 @@ func WatchlistAddHandler(client *api.APIClient, ctx context.Context) server.Tool
 	}
 }
 
-func WatchlistRemoveHandler(client *api.APIClient, ctx context.Context) server.ToolHandlerFunc {
+func WatchlistRemoveHandler() server.ToolHandlerFunc {
 	return func(callCtx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		tmdbId, err := req.RequireString("tmdbId")
 		if err != nil {
 			return nil, err
 		}
-		_, err = client.WatchlistAPI.WatchlistTmdbIdDelete(ctx, tmdbId).Execute()
+		client := newAPIClientWithKey(apiKeyFromContext(callCtx))
+		_, err = client.WatchlistAPI.WatchlistTmdbIdDelete(callCtx, tmdbId).Execute()
 		if err != nil {
 			return nil, fmt.Errorf("WatchlistTmdbIdDelete failed: %w", err)
 		}

--- a/tests/mcp_serve_test.go
+++ b/tests/mcp_serve_test.go
@@ -54,8 +54,7 @@ func TestMCPStatusSystemHandler(t *testing.T) {
 	defer cleanup()
 	_ = ts
 
-	client, ctx := cmdmcp.NewAPIClientForTest()
-	handler := cmdmcp.StatusSystemHandler(client, ctx)
+	handler := cmdmcp.StatusSystemHandler()
 
 	result := callTool(t, handler, nil)
 	text := resultText(t, result)
@@ -77,8 +76,7 @@ func TestMCPSearchMultiHandler(t *testing.T) {
 	defer cleanup()
 	_ = ts
 
-	client, ctx := cmdmcp.NewAPIClientForTest()
-	handler := cmdmcp.SearchMultiHandler(client, ctx)
+	handler := cmdmcp.SearchMultiHandler()
 
 	result := callTool(t, handler, map[string]any{"query": "batman"})
 	text := resultText(t, result)
@@ -93,8 +91,7 @@ func TestMCPSearchMultiHandlerMissingQuery(t *testing.T) {
 	defer cleanup()
 	_ = ts
 
-	client, ctx := cmdmcp.NewAPIClientForTest()
-	handler := cmdmcp.SearchMultiHandler(client, ctx)
+	handler := cmdmcp.SearchMultiHandler()
 
 	req := mcp.CallToolRequest{}
 	req.Params.Arguments = map[string]any{}
@@ -115,8 +112,7 @@ func TestMCPRequestListHandler(t *testing.T) {
 	defer cleanup()
 	_ = ts
 
-	client, ctx := cmdmcp.NewAPIClientForTest()
-	handler := cmdmcp.RequestListHandler(client, ctx)
+	handler := cmdmcp.RequestListHandler()
 
 	result := callTool(t, handler, nil)
 	text := resultText(t, result)
@@ -137,8 +133,7 @@ func TestMCPRequestCountHandler(t *testing.T) {
 	defer cleanup()
 	_ = ts
 
-	client, ctx := cmdmcp.NewAPIClientForTest()
-	handler := cmdmcp.RequestCountHandler(client, ctx)
+	handler := cmdmcp.RequestCountHandler()
 
 	result := callTool(t, handler, nil)
 	text := resultText(t, result)
@@ -159,8 +154,7 @@ func TestMCPMoviesGetHandler(t *testing.T) {
 	defer cleanup()
 	_ = ts
 
-	client, ctx := cmdmcp.NewAPIClientForTest()
-	handler := cmdmcp.MoviesGetHandler(client, ctx)
+	handler := cmdmcp.MoviesGetHandler()
 
 	result := callTool(t, handler, map[string]any{"movieId": float64(550)})
 	text := resultText(t, result)
@@ -182,8 +176,7 @@ func TestMCPTVGetHandler(t *testing.T) {
 	defer cleanup()
 	_ = ts
 
-	client, ctx := cmdmcp.NewAPIClientForTest()
-	handler := cmdmcp.TVGetHandler(client, ctx)
+	handler := cmdmcp.TVGetHandler()
 
 	result := callTool(t, handler, map[string]any{"tvId": float64(1399)})
 	text := resultText(t, result)
@@ -205,8 +198,7 @@ func TestMCPIssueCountHandler(t *testing.T) {
 	defer cleanup()
 	_ = ts
 
-	client, ctx := cmdmcp.NewAPIClientForTest()
-	handler := cmdmcp.IssueCountHandler(client, ctx)
+	handler := cmdmcp.IssueCountHandler()
 
 	result := callTool(t, handler, nil)
 	text := resultText(t, result)
@@ -227,8 +219,7 @@ func TestMCPUsersListHandler(t *testing.T) {
 	defer cleanup()
 	_ = ts
 
-	client, ctx := cmdmcp.NewAPIClientForTest()
-	handler := cmdmcp.UsersListHandler(client, ctx)
+	handler := cmdmcp.UsersListHandler()
 
 	result := callTool(t, handler, nil)
 	text := resultText(t, result)
@@ -249,8 +240,7 @@ func TestMCPServiceRadarrListHandler(t *testing.T) {
 	defer cleanup()
 	_ = ts
 
-	client, ctx := cmdmcp.NewAPIClientForTest()
-	handler := cmdmcp.ServiceRadarrListHandler(client, ctx)
+	handler := cmdmcp.ServiceRadarrListHandler()
 
 	result := callTool(t, handler, nil)
 	text := resultText(t, result)
@@ -276,8 +266,7 @@ func TestMCPSettingsAboutHandler(t *testing.T) {
 	defer cleanup()
 	_ = ts
 
-	client, ctx := cmdmcp.NewAPIClientForTest()
-	handler := cmdmcp.SettingsAboutHandler(client, ctx)
+	handler := cmdmcp.SettingsAboutHandler()
 
 	result := callTool(t, handler, nil)
 	text := resultText(t, result)
@@ -298,11 +287,75 @@ func TestMCPBlocklistListHandler(t *testing.T) {
 	defer cleanup()
 	_ = ts
 
-	client, ctx := cmdmcp.NewAPIClientForTest()
-	handler := cmdmcp.BlocklistListHandler(client, ctx)
+	handler := cmdmcp.BlocklistListHandler()
 
 	result := callTool(t, handler, nil)
 	text := resultText(t, result)
 
 	assert.Contains(t, text, `"results"`)
+}
+
+// --- Multi-tenancy tests ---
+
+func TestTenantRoutingExtractsToken(t *testing.T) {
+	var capturedPath string
+	var capturedKey string
+
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedPath = r.URL.Path
+		capturedKey, _ = r.Context().Value(cmdmcp.APIKeyContextKey).(string)
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := cmdmcp.TenantRoutingHandler(inner)
+
+	req := httptest.NewRequest(http.MethodGet, "/mytoken/mcp", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "/mcp", capturedPath)
+	assert.Equal(t, "mytoken", capturedKey)
+}
+
+func TestTenantRoutingRejects404(t *testing.T) {
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	handler := cmdmcp.TenantRoutingHandler(inner)
+
+	for _, path := range []string{"/mcp", "/", "/nopath"} {
+		req := httptest.NewRequest(http.MethodGet, path, nil)
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+		assert.Equal(t, http.StatusNotFound, rec.Code, "path %q should return 404", path)
+	}
+}
+
+func TestMultiTenantAPIKeyPropagation(t *testing.T) {
+	var receivedAPIKey string
+
+	ts, cleanup := newMCPTestServer(func(w http.ResponseWriter, r *http.Request) {
+		receivedAPIKey = r.Header.Get("X-Api-Key")
+		if r.URL.Path == "/api/v1/status" {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"version":"1.0.0"}`))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	})
+	defer cleanup()
+	_ = ts
+
+	handler := cmdmcp.StatusSystemHandler()
+
+	ctx := context.WithValue(context.Background(), cmdmcp.APIKeyContextKey, "tenant-api-key")
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = nil
+	result, err := handler(ctx, req)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, "tenant-api-key", receivedAPIKey)
 }


### PR DESCRIPTION
## Summary

- Add `--multi-tenant` flag to `mcp serve --transport http`: routes `/{seer-api-token}/mcp` so each caller's token is extracted from the URL path and sent as `X-Api-Key` to the Seer API
- Refactor all 14 tool files and 43 handlers to derive a fresh API client per call using `newAPIClientWithKey(apiKeyFromContext(callCtx))` — removing the closed-over shared `client/ctx`; single-tenant and stdio modes are fully unchanged
- Add `TenantRoutingHandler` (exported for tests) and three new tests: token extraction, 404 rejection, and end-to-end API key propagation

## Test plan

- [ ] All existing tests pass: `go test -v ./...`
- [ ] Build succeeds: `go build`
- [ ] Single-tenant: `seer-cli mcp serve --transport http --no-auth` → `X-Api-Key` from `SEER_API_KEY` as before
- [ ] Multi-tenant: `seer-cli mcp serve --transport http --no-auth --multi-tenant` → `/token-A/mcp` sends `X-Api-Key: token-A`, `/mcp` returns 404
- [ ] `--multi-tenant` without `--transport http` returns an error