### PR TITLE
feat(mcp): add route-token secret path and CORS support for HTTP transport

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -42,6 +42,7 @@ Supports Linux and macOS (amd64 / arm64).
 Run the MCP HTTP server in a container next to your Seer instance:
 
 ```bash
+# With Bearer token auth
 docker run --rm \
   -e SEER_SERVER=http://your-seer-instance:5055 \
   -e SEER_API_KEY=your-api-key \
@@ -52,7 +53,22 @@ docker run --rm \
 
 MCP endpoint: `http://localhost:8811/mcp` — set `Authorization: Bearer your-secret-token` in your MCP client.
 
-`SEER_MCP_AUTH_TOKEN` is required for HTTP transport. Omitting it will produce an error unless you also pass `--no-auth` (insecure).
+For clients that cannot send custom headers (e.g. claude.ai remote MCP), use a secret path prefix:
+
+```bash
+docker run --rm \
+  -e SEER_SERVER=http://your-seer-instance:5055 \
+  -e SEER_API_KEY=your-api-key \
+  -e SEER_MCP_ROUTE_TOKEN=your-secret-path \
+  -e SEER_MCP_NO_AUTH=true \
+  -e SEER_MCP_CORS=true \
+  -p 8811:8811 \
+  ghcr.io/electather/seer-cli:latest
+```
+
+MCP endpoint: `http://localhost:8811/your-secret-path/mcp` — no auth header required.
+
+At least one of `SEER_MCP_AUTH_TOKEN`, `SEER_MCP_ROUTE_TOKEN`, or `SEER_MCP_NO_AUTH=true` must be set for HTTP transport.
 
 ### docker-compose deployment
 
@@ -329,6 +345,35 @@ seer-cli mcp serve --transport http --addr :8811 --auth-token mysecrettoken
 ```
 
 Endpoint: `http://localhost:8811/mcp` — set `Authorization: Bearer mysecrettoken` in your client.
+
+For clients that cannot send custom headers (e.g. claude.ai remote MCP), use a secret path prefix via `--route-token` (or `SEER_MCP_ROUTE_TOKEN`):
+
+```bash
+# Add --cors if connecting from a browser-based client (e.g. claude.ai)
+seer-cli mcp serve --transport http --addr :8811 --route-token abc123 --no-auth --cors
+# Endpoint becomes: http://localhost:8811/abc123/mcp
+```
+
+Both methods can be combined for defense in depth:
+
+```bash
+seer-cli mcp serve --transport http --route-token abc123 --auth-token mysecrettoken
+```
+
+All flags are configurable via environment variables:
+
+| Flag | Environment variable | Default |
+|------|---------------------|---------|
+| `--transport` | `SEER_MCP_TRANSPORT` | `stdio` |
+| `--addr` | `SEER_MCP_ADDR` | `:8811` |
+| `--auth-token` | `SEER_MCP_AUTH_TOKEN` | — |
+| `--no-auth` | `SEER_MCP_NO_AUTH` | `false` |
+| `--route-token` | `SEER_MCP_ROUTE_TOKEN` | — |
+| `--cors` | `SEER_MCP_CORS` | `false` |
+| `--tls-cert` | `SEER_MCP_TLS_CERT` | — |
+| `--tls-key` | `SEER_MCP_TLS_KEY` | — |
+
+> Pass `--cors` (or `SEER_MCP_CORS=true`) to enable CORS headers for browser-based clients (e.g. claude.ai). Disabled by default.
 
 > The HTTP transport does not implement OAuth 2.0. Use stdio for Claude Desktop.
 

--- a/README.md
+++ b/README.md
@@ -359,7 +359,7 @@ Restart Claude Desktop. The Seer tools will appear automatically.
 For clients that support HTTP MCP with Bearer token authentication:
 
 ```sh
-# Start with a secret token
+# Start with a Bearer token
 seer-cli mcp serve --transport http --addr :8811 --auth-token mysecrettoken
 
 # With TLS
@@ -374,13 +374,46 @@ seer-cli mcp serve --transport http --addr :8811 --no-auth
 
 The MCP endpoint will be `http://localhost:8811/mcp`. Configure your client with `Authorization: Bearer mysecrettoken`.
 
-> **Note:** The HTTP transport uses Bearer token auth. It does not implement OAuth 2.0, so it is not compatible with clients that require OAuth (e.g. claude.ai remote MCP). Use stdio for Claude Desktop.
+#### Secret path prefix (for clients that cannot send custom headers)
+
+Some MCP clients (e.g. claude.ai remote MCP integration) do not support custom `Authorization` headers. Use `--route-token` to embed a secret in the URL path instead:
+
+```sh
+# Endpoint becomes http://localhost:8811/abc123/mcp — no auth header needed
+seer-cli mcp serve --transport http --addr :8811 --route-token abc123 --no-auth
+
+# Add --cors for browser-based clients (e.g. claude.ai)
+seer-cli mcp serve --transport http --addr :8811 --route-token abc123 --no-auth --cors
+
+# Combine with Bearer auth for defense in depth
+seer-cli mcp serve --transport http --addr :8811 --route-token abc123 --auth-token mysecrettoken
+```
+
+> **Note:** A secret path is weaker than a proper Bearer token since it may appear in proxy logs. For production use, combine it with TLS.
+
+> **Note:** The HTTP transport does not implement OAuth 2.0 and is not compatible with clients that require OAuth. Use stdio for Claude Desktop.
+
+#### Environment variables
+
+All `mcp serve` flags can be set via environment variables, which is especially useful for Docker deployments:
+
+| Flag | Environment variable | Default |
+|------|---------------------|---------|
+| `--transport` | `SEER_MCP_TRANSPORT` | `stdio` |
+| `--addr` | `SEER_MCP_ADDR` | `:8811` |
+| `--auth-token` | `SEER_MCP_AUTH_TOKEN` | — |
+| `--no-auth` | `SEER_MCP_NO_AUTH` | `false` |
+| `--route-token` | `SEER_MCP_ROUTE_TOKEN` | — |
+| `--cors` | `SEER_MCP_CORS` | `false` |
+| `--tls-cert` | `SEER_MCP_TLS_CERT` | — |
+| `--tls-key` | `SEER_MCP_TLS_KEY` | — |
 
 ### Docker (HTTP transport)
 
 The published container image runs the MCP HTTP server by default. This is the recommended way to self-host the MCP server:
 
 ```sh
+# With Bearer token auth
 docker run -d \
   --name seer-mcp \
   -p 8811:8811 \
@@ -393,6 +426,23 @@ docker run -d \
 Configure your MCP client with:
 - **URL:** `http://localhost:8811/mcp`
 - **Authorization:** `Bearer mysecrettoken`
+
+For clients that cannot send custom headers (e.g. claude.ai remote MCP), use a secret path prefix instead:
+
+```sh
+docker run -d \
+  --name seer-mcp \
+  -p 8811:8811 \
+  -e SEER_SERVER=https://your-seer-instance.com \
+  -e SEER_API_KEY=your-api-key \
+  -e SEER_MCP_ROUTE_TOKEN=abc123 \
+  -e SEER_MCP_NO_AUTH=true \
+  -e SEER_MCP_CORS=true \
+  ghcr.io/electather/seer-cli:latest
+```
+
+Configure your MCP client with:
+- **URL:** `http://localhost:8811/abc123/mcp`
 
 To bind to a different port or address, pass `--addr` explicitly:
 

--- a/cmd/mcp/serve.go
+++ b/cmd/mcp/serve.go
@@ -25,32 +25,53 @@ var serveCmd = &cobra.Command{
   # Start over HTTPS with TLS
   seer-cli mcp serve --transport http --auth-token mysecret --tls-cert /path/to/cert.pem --tls-key /path/to/key.pem
 
+  # Start over HTTP with a secret path prefix (for clients that cannot send custom headers)
+  seer-cli mcp serve --transport http --route-token abc123 --no-auth
+  # MCP endpoint becomes: http://localhost:8811/abc123/mcp
+
+  # Enable CORS for browser-based clients (e.g. claude.ai)
+  seer-cli mcp serve --transport http --route-token abc123 --no-auth --cors
+
+  # Combine both auth methods for defense in depth
+  seer-cli mcp serve --transport http --route-token abc123 --auth-token mysecret
+
   # Start over HTTP without auth (insecure, not recommended)
   seer-cli mcp serve --transport http --no-auth`,
 	RunE: runServe,
 }
 
 func init() {
-	serveCmd.Flags().String("transport", "stdio", "Transport protocol: stdio or http")
-	serveCmd.Flags().String("addr", ":8811", "HTTP bind address (http transport only)")
-	serveCmd.Flags().String("auth-token", "", "Bearer token required for HTTP transport")
-	serveCmd.Flags().Bool("no-auth", false, "Disable authentication (insecure — must be explicit)")
-	serveCmd.Flags().String("tls-cert", "", "Path to TLS certificate file")
-	serveCmd.Flags().String("tls-key", "", "Path to TLS private key file")
+	serveCmd.Flags().String("transport", "stdio", "Transport protocol: stdio or http (env: SEER_MCP_TRANSPORT)")
+	serveCmd.Flags().String("addr", ":8811", "HTTP bind address (http transport only) (env: SEER_MCP_ADDR)")
+	serveCmd.Flags().String("auth-token", "", "Bearer token required for HTTP transport (env: SEER_MCP_AUTH_TOKEN)")
+	serveCmd.Flags().Bool("no-auth", false, "Disable authentication (insecure — must be explicit) (env: SEER_MCP_NO_AUTH)")
+	serveCmd.Flags().String("route-token", "", "Secret path prefix for the MCP endpoint (e.g. 'abc123' → /abc123/mcp). Useful for clients that cannot send custom headers (env: SEER_MCP_ROUTE_TOKEN)")
+	serveCmd.Flags().String("tls-cert", "", "Path to TLS certificate file (env: SEER_MCP_TLS_CERT)")
+	serveCmd.Flags().String("tls-key", "", "Path to TLS private key file (env: SEER_MCP_TLS_KEY)")
+	serveCmd.Flags().Bool("cors", false, "Enable CORS headers (required for browser-based clients such as claude.ai) (env: SEER_MCP_CORS)")
+	viper.BindPFlag("mcp_transport", serveCmd.Flags().Lookup("transport"))
+	viper.BindPFlag("mcp_addr", serveCmd.Flags().Lookup("addr"))
 	viper.BindPFlag("mcp_auth_token", serveCmd.Flags().Lookup("auth-token"))
+	viper.BindPFlag("mcp_no_auth", serveCmd.Flags().Lookup("no-auth"))
+	viper.BindPFlag("mcp_route_token", serveCmd.Flags().Lookup("route-token"))
+	viper.BindPFlag("mcp_tls_cert", serveCmd.Flags().Lookup("tls-cert"))
+	viper.BindPFlag("mcp_tls_key", serveCmd.Flags().Lookup("tls-key"))
+	viper.BindPFlag("mcp_cors", serveCmd.Flags().Lookup("cors"))
 	Cmd.AddCommand(serveCmd)
 }
 
-func runServe(cmd *cobra.Command, args []string) error {
-	transport, _ := cmd.Flags().GetString("transport")
-	addr, _ := cmd.Flags().GetString("addr")
+func runServe(_ *cobra.Command, args []string) error {
+	transport := viper.GetString("mcp_transport")
+	addr := viper.GetString("mcp_addr")
 	authToken := viper.GetString("mcp_auth_token")
-	noAuth, _ := cmd.Flags().GetBool("no-auth")
-	tlsCert, _ := cmd.Flags().GetString("tls-cert")
-	tlsKey, _ := cmd.Flags().GetString("tls-key")
+	routeToken := viper.GetString("mcp_route_token")
+	noAuth := viper.GetBool("mcp_no_auth")
+	tlsCert := viper.GetString("mcp_tls_cert")
+	tlsKey := viper.GetString("mcp_tls_key")
+	cors := viper.GetBool("mcp_cors")
 
-	if transport == "http" && authToken == "" && !noAuth {
-		return fmt.Errorf("HTTP transport requires --auth-token or --no-auth (insecure) to be set explicitly")
+	if transport == "http" && authToken == "" && routeToken == "" && !noAuth {
+		return fmt.Errorf("HTTP transport requires --auth-token, --route-token, or --no-auth (insecure) to be set explicitly")
 	}
 
 	verbose := viper.GetBool("verbose")
@@ -95,7 +116,11 @@ func runServe(cmd *cobra.Command, args []string) error {
 		if strings.HasPrefix(host, ":") {
 			host = "localhost" + host
 		}
-		endpoint := fmt.Sprintf("%s://%s/mcp", scheme, host)
+		mcpPath := "/mcp"
+		if routeToken != "" {
+			mcpPath = "/" + routeToken + "/mcp"
+		}
+		endpoint := fmt.Sprintf("%s://%s%s", scheme, host, mcpPath)
 
 		fmt.Fprintf(os.Stderr, "seer-mcp: listening on %s\n", endpoint)
 		fmt.Fprintf(os.Stderr, "\nConfigure your MCP client:\n")
@@ -103,7 +128,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 		if authToken != "" {
 			fmt.Fprintf(os.Stderr, "  Authorization: Bearer %s\n", authToken)
 		} else {
-			fmt.Fprintf(os.Stderr, "  Authorization: none (--no-auth)\n")
+			fmt.Fprintf(os.Stderr, "  Authorization: none\n")
 		}
 
 		if verbose {
@@ -112,16 +137,32 @@ func runServe(cmd *cobra.Command, args []string) error {
 			fmt.Fprintf(os.Stderr, "  Seer API → %s\n", seerServer)
 			fmt.Fprintf(os.Stderr, "  Bind addr: %s\n", addr)
 			fmt.Fprintf(os.Stderr, "  TLS: %v\n", tlsCert != "")
-			fmt.Fprintf(os.Stderr, "  Auth: %v\n", authToken != "")
+			fmt.Fprintf(os.Stderr, "  Auth token: %v\n", authToken != "")
+			fmt.Fprintf(os.Stderr, "  Route token: %v\n", routeToken != "")
+			fmt.Fprintf(os.Stderr, "  CORS: %v\n", cors)
 			fmt.Fprintf(os.Stderr, "  Tools registered: 43\n")
 		}
 
 		fmt.Fprintf(os.Stderr, "\n")
 
 		httpHandler := server.NewStreamableHTTPServer(s)
-		var handler http.Handler = httpHandler
+		var handler http.Handler
+		if routeToken != "" {
+			// Strip the route-token prefix so mcp-go still sees /mcp, /mcp/sse, etc.
+			prefix := "/" + routeToken
+			mux := http.NewServeMux()
+			mux.Handle(prefix+"/", http.StripPrefix(prefix, httpHandler))
+			handler = mux
+		} else {
+			handler = httpHandler
+		}
 		if authToken != "" {
-			handler = bearerAuthMiddleware(authToken, httpHandler)
+			handler = bearerAuthMiddleware(authToken, handler)
+		}
+		// CORS must be outermost so browser preflight OPTIONS requests are never
+		// blocked by auth middleware.
+		if cors {
+			handler = corsMiddleware(handler)
 		}
 		srv := &http.Server{
 			Addr:    addr,
@@ -134,6 +175,20 @@ func runServe(cmd *cobra.Command, args []string) error {
 	default:
 		return fmt.Errorf("unknown transport %q: must be stdio or http", transport)
 	}
+}
+
+func corsMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, DELETE, OPTIONS")
+		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization, Mcp-Session-Id, Accept")
+		w.Header().Set("Access-Control-Expose-Headers", "Mcp-Session-Id")
+		if r.Method == http.MethodOptions {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
 }
 
 func bearerAuthMiddleware(token string, next http.Handler) http.Handler {


### PR DESCRIPTION
## Summary

- **`--route-token` / `SEER_MCP_ROUTE_TOKEN`**: mounts the MCP endpoint at `/<token>/mcp` instead of `/mcp`, enabling auth-via-URL-path for clients that cannot send custom `Authorization` headers (e.g. claude.ai remote MCP integration)
- **`--cors` / `SEER_MCP_CORS`**: opt-in CORS middleware that handles `OPTIONS` preflight and sets `Access-Control-Allow-*` headers — required for browser-based MCP clients; disabled by default
- **Full env var coverage**: all remaining `mcp serve` flags (`--transport`, `--addr`, `--no-auth`, `--tls-cert`, `--tls-key`) are now bound to Viper and readable from environment variables, making pure-env Docker deployments possible with no CMD override

## Test plan

- [ ] `seer-cli mcp serve --transport http --route-token abc123 --no-auth` — endpoint is at `/abc123/mcp`, requests to `/mcp` return 404
- [ ] `SEER_MCP_ROUTE_TOKEN=abc123 SEER_MCP_NO_AUTH=true SEER_MCP_TRANSPORT=http seer-cli mcp serve` — same result via env vars only
- [ ] `--cors` flag: OPTIONS preflight returns 204 with `Access-Control-Allow-Origin: *`; without the flag, no CORS headers are sent
- [ ] `SEER_MCP_CORS=true` achieves the same as `--cors`
- [ ] Bearer `--auth-token` still works alongside `--route-token`
- [ ] Docker: run with `SEER_MCP_ROUTE_TOKEN`, `SEER_MCP_NO_AUTH=true`, `SEER_MCP_CORS=true` and connect from claude.ai