### PR TITLE
chore(github): add PR and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,71 @@
+name: Bug report
+description: Something isn't working as expected
+labels: [bug]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug. Please fill in as much detail as you can.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear and concise description of the bug.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to reproduce
+      description: Exact commands or steps that trigger the bug.
+      placeholder: |
+        1. Run `seer-cli ...`
+        2. See error
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behaviour
+      description: What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behaviour
+      description: What actually happened? Include the full error output.
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: seer-cli version
+      description: Run `seer-cli --version` and paste the output.
+      placeholder: v0.x.y
+    validations:
+      required: true
+
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating system
+      options:
+        - Linux
+        - macOS
+        - Windows
+        - Docker
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Config file (redact secrets), Seer version, relevant logs, etc.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Question or discussion
+    url: https://github.com/electather/seer-cli/discussions
+    about: Ask questions or share ideas in Discussions rather than opening an issue.
+  - name: Seer (upstream) issues
+    url: https://github.com/seerr/app/issues
+    about: Bugs in the Seer web app itself belong in the upstream repo.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,39 @@
+name: Feature request
+description: Suggest a new command, flag, or improvement
+labels: [enhancement]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the suggestion! Please provide enough detail for us to evaluate and implement it.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / motivation
+      description: What problem does this solve, or what workflow does it enable?
+      placeholder: "Currently I have to... and it would be easier if..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: Describe the feature. Include the command/flag syntax if relevant.
+      placeholder: |
+        Add a `seer-cli movies watch` command that...
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Any workarounds or alternative approaches you considered?
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Links to Seer API docs, related issues, screenshots, etc.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,23 @@
+## Summary
+
+<!-- What does this PR do? Why? Link to any relevant issue: "Closes #NNN" -->
+
+## Changes
+
+<!-- Bullet list of the key changes made -->
+
+-
+
+## Test plan
+
+<!-- How did you verify this works? Include commands to reproduce. -->
+
+- [ ] `go test -v ./...` passes
+- [ ] `go fmt ./...` produces no diff
+- [ ] `go build` succeeds
+
+## Checklist
+
+- [ ] New tests added for new behaviour
+- [ ] Documentation updated (README, command `--help`, comments)
+- [ ] No unrelated changes included


### PR DESCRIPTION
## Summary

Adds standard GitHub contribution templates for the project.

## Changes

- `.github/PULL_REQUEST_TEMPLATE.md` — pre-filled PR template with summary, changes, test plan, and checklist sections; aligns with the conventions already documented in `CLAUDE.md`.
- `.github/ISSUE_TEMPLATE/bug_report.yml` — structured bug report form (description, repro steps, expected/actual behaviour, version, OS).
- `.github/ISSUE_TEMPLATE/feature_request.yml` — structured feature request form (problem/motivation, proposed solution, alternatives).
- `.github/ISSUE_TEMPLATE/config.yml` — disables blank issues; redirects general questions to Discussions and upstream Seer bugs to the Seer repo.

## Test plan

- [x] Open a new PR on GitHub and verify the template pre-populates.
- [x] Open a new issue on GitHub and verify the two form options appear (no blank issue option).

## Checklist

- [x] No code changes — documentation/meta only.
- [x] No tests required.