### PR TITLE
feat(config): structured config format, JSON schema, and dynamic MCP config support

### DIFF
--- a/cmd/config/set.go
+++ b/cmd/config/set.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -9,6 +10,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"gopkg.in/yaml.v3"
+	"seer-cli/cmd/mcp"
 )
 
 const schemaComment = "# yaml-language-server: $schema=https://raw.githubusercontent.com/electather/seer-cli/main/seer-cli.schema.json\n"
@@ -16,7 +18,16 @@ const schemaComment = "# yaml-language-server: $schema=https://raw.githubusercon
 var configSetCmd = &cobra.Command{
 	Use:   "set",
 	Short: "Persist configuration to the config file",
-	Long:  `Save the server URL and API key provided as flags to the CLI configuration file (~/.seer-cli.yaml by default).`,
+	Long: `Save configuration to the CLI config file (~/.seer-cli.yaml by default).
+
+Accepts the global --server and --api-key flags for Seer instance settings,
+and all MCP server flags (same as 'mcp serve') for MCP settings.`,
+	Example: `  # Set Seer instance
+  seer-cli config set --server https://seer.example.com --api-key mykey
+
+  # Set Seer instance and configure the MCP server for HTTP transport
+  seer-cli config set --server https://seer.example.com --api-key mykey \
+    --transport http --auth-token mysecret`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		configPath := viper.ConfigFileUsed()
 		if configPath == "" {
@@ -28,12 +39,30 @@ var configSetCmd = &cobra.Command{
 			viper.SetConfigFile(configPath)
 		}
 
+		// Promote explicitly-passed root flags into Viper.
 		if s, _ := cmd.Root().PersistentFlags().GetString("server"); s != "" {
 			viper.Set("seer.server", s)
 		}
-
 		if k, _ := cmd.Root().PersistentFlags().GetString("api-key"); k != "" {
 			viper.Set("seer.api_key", k)
+		}
+
+		// Promote explicitly-passed MCP flags into Viper without touching the
+		// serve command's Viper bindings. We only propagate flags that the user
+		// actually provided (flag.Changed), leaving existing config-file values
+		// for everything else.
+		for _, f := range mcp.ServeFlags {
+			flag := cmd.Flags().Lookup(f.Name)
+			if flag == nil || !flag.Changed {
+				continue
+			}
+			if f.IsBool {
+				val, _ := cmd.Flags().GetBool(f.Name)
+				viper.Set(f.ViperKey, val)
+			} else {
+				val, _ := cmd.Flags().GetString(f.Name)
+				viper.Set(f.ViperKey, val)
+			}
 		}
 
 		if err := writeStructuredConfig(configPath); err != nil {
@@ -45,103 +74,110 @@ var configSetCmd = &cobra.Command{
 	},
 }
 
-// writeStructuredConfig writes only non-empty config values as structured YAML
-// with a yaml-language-server schema comment for IDE autocomplete support.
+// writeStructuredConfig writes only non-empty/non-default config values as
+// structured YAML with a yaml-language-server schema comment.
 func writeStructuredConfig(path string) error {
-	cfg := buildConfig()
+	root := &yaml.Node{Kind: yaml.MappingNode}
 
-	raw, err := yaml.Marshal(cfg)
-	if err != nil {
+	if seerNode := buildSeerNode(); seerNode != nil {
+		root.Content = append(root.Content,
+			scalarNode("seer"),
+			seerNode,
+		)
+	}
+
+	if mcpNode := buildMCPNode(); mcpNode != nil {
+		root.Content = append(root.Content,
+			scalarNode("mcp"),
+			mcpNode,
+		)
+	}
+
+	if len(root.Content) == 0 {
+		// Nothing to write — produce an empty document.
+		return os.WriteFile(path, []byte(schemaComment), 0600)
+	}
+
+	var buf bytes.Buffer
+	enc := yaml.NewEncoder(&buf)
+	enc.SetIndent(2)
+	if err := enc.Encode(&yaml.Node{Kind: yaml.DocumentNode, Content: []*yaml.Node{root}}); err != nil {
 		return err
 	}
+	enc.Close()
 
-	content := schemaComment + string(raw)
-	return os.WriteFile(path, []byte(content), 0600)
+	return os.WriteFile(path, []byte(schemaComment+buf.String()), 0600)
 }
 
-// configFile is the serialisation model for the YAML config file.
-// Struct field order determines the YAML key order in the written file.
-// Fields tagged with omitempty are omitted when they hold their zero value.
-type configFile struct {
-	Seer *seerSection `yaml:"seer,omitempty"`
-	MCP  *mcpSection  `yaml:"mcp,omitempty"`
+// buildSeerNode returns a YAML mapping node for the seer: section, or nil if
+// neither server nor api_key is set.
+func buildSeerNode() *yaml.Node {
+	server := strings.TrimRight(viper.GetString("seer.server"), "/")
+	apiKey := viper.GetString("seer.api_key")
+
+	if server == "" && apiKey == "" {
+		return nil
+	}
+
+	node := &yaml.Node{Kind: yaml.MappingNode}
+	if server != "" {
+		node.Content = append(node.Content, scalarNode("server"), scalarNode(server))
+	}
+	if apiKey != "" {
+		node.Content = append(node.Content, scalarNode("api_key"), scalarNode(apiKey))
+	}
+	return node
 }
 
-type seerSection struct {
-	Server string `yaml:"server,omitempty"`
-	APIKey string `yaml:"api_key,omitempty"`
+// buildMCPNode returns a YAML mapping node for the mcp: section driven entirely
+// by mcp.ServeFlags. A key is included only when viper.IsSet reports the value
+// was explicitly configured (flag, env var, or config file) — defaults are never
+// written. Returns nil when no MCP setting is active.
+func buildMCPNode() *yaml.Node {
+	node := &yaml.Node{Kind: yaml.MappingNode}
+
+	for _, f := range mcp.ServeFlags {
+		if !viper.IsSet(f.ViperKey) {
+			continue
+		}
+		// YAML key: take the part of the Viper key after the first dot.
+		yamlKey := f.ViperKey
+		if idx := strings.Index(f.ViperKey, "."); idx >= 0 {
+			yamlKey = f.ViperKey[idx+1:]
+		}
+
+		var valNode *yaml.Node
+		if f.IsBool {
+			valNode = boolNode(viper.GetBool(f.ViperKey))
+		} else {
+			valNode = scalarNode(viper.GetString(f.ViperKey))
+		}
+		node.Content = append(node.Content, scalarNode(yamlKey), valNode)
+	}
+
+	if len(node.Content) == 0 {
+		return nil
+	}
+	return node
 }
 
-type mcpSection struct {
-	Transport   string `yaml:"transport,omitempty"`
-	Addr        string `yaml:"addr,omitempty"`
-	AuthToken   string `yaml:"auth_token,omitempty"`
-	NoAuth      bool   `yaml:"no_auth,omitempty"`
-	RouteToken  string `yaml:"route_token,omitempty"`
-	TLSCert     string `yaml:"tls_cert,omitempty"`
-	TLSKey      string `yaml:"tls_key,omitempty"`
-	CORS        bool   `yaml:"cors,omitempty"`
-	MultiTenant bool   `yaml:"multi_tenant,omitempty"`
-	LogFile     string `yaml:"log_file,omitempty"`
-	LogLevel    string `yaml:"log_level,omitempty"`
-	LogFormat   string `yaml:"log_format,omitempty"`
+// scalarNode creates a plain YAML scalar node.
+func scalarNode(value string) *yaml.Node {
+	return &yaml.Node{Kind: yaml.ScalarNode, Value: value}
 }
 
-// buildConfig assembles the config from Viper, omitting default and empty
-// values so the written file stays minimal.
-func buildConfig() configFile {
-	var cfg configFile
-
-	seer := &seerSection{}
-	if v := viper.GetString("seer.server"); v != "" {
-		seer.Server = strings.TrimRight(v, "/")
+// boolNode creates a YAML bool scalar node.
+func boolNode(value bool) *yaml.Node {
+	v := "false"
+	if value {
+		v = "true"
 	}
-	if v := viper.GetString("seer.api_key"); v != "" {
-		seer.APIKey = v
-	}
-	if seer.Server != "" || seer.APIKey != "" {
-		cfg.Seer = seer
-	}
-
-	mcp := &mcpSection{}
-	if v := viper.GetString("mcp.transport"); v != "" && v != "stdio" {
-		mcp.Transport = v
-	}
-	if v := viper.GetString("mcp.addr"); v != "" && v != ":8811" {
-		mcp.Addr = v
-	}
-	if v := viper.GetString("mcp.auth_token"); v != "" {
-		mcp.AuthToken = v
-	}
-	mcp.NoAuth = viper.GetBool("mcp.no_auth")
-	if v := viper.GetString("mcp.route_token"); v != "" {
-		mcp.RouteToken = v
-	}
-	if v := viper.GetString("mcp.tls_cert"); v != "" {
-		mcp.TLSCert = v
-	}
-	if v := viper.GetString("mcp.tls_key"); v != "" {
-		mcp.TLSKey = v
-	}
-	mcp.CORS = viper.GetBool("mcp.cors")
-	mcp.MultiTenant = viper.GetBool("mcp.multi_tenant")
-	if v := viper.GetString("mcp.log_file"); v != "" {
-		mcp.LogFile = v
-	}
-	if v := viper.GetString("mcp.log_level"); v != "" && v != "info" {
-		mcp.LogLevel = v
-	}
-	if v := viper.GetString("mcp.log_format"); v != "" && v != "text" {
-		mcp.LogFormat = v
-	}
-	// Only write the mcp section when at least one non-default value is present.
-	if *mcp != (mcpSection{}) {
-		cfg.MCP = mcp
-	}
-
-	return cfg
+	return &yaml.Node{Kind: yaml.ScalarNode, Value: v, Tag: "!!bool"}
 }
 
 func init() {
+	// Register the same MCP flags as 'mcp serve' so users can configure them
+	// with 'config set' without Viper binding conflicts.
+	mcp.RegisterFlags(configSetCmd)
 	Cmd.AddCommand(configSetCmd)
 }

--- a/cmd/mcp/flags.go
+++ b/cmd/mcp/flags.go
@@ -1,0 +1,125 @@
+package mcp
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+// FlagDef is the authoritative description of a single mcp-serve flag.
+// Adding an entry here automatically propagates to both the serve command and
+// the config set command — no other files need to be updated.
+type FlagDef struct {
+	// Name is the cobra flag name (e.g. "auth-token").
+	Name string
+	// ViperKey is the dot-notation Viper key (e.g. "mcp.auth_token").
+	ViperKey string
+	// Default is the zero/default value as a string (e.g. "stdio", "false").
+	Default string
+	// Usage is the help text shown by --help.
+	Usage string
+	// IsBool marks flags that are registered as Bool rather than String.
+	IsBool bool
+}
+
+// ServeFlags is the single source of truth for all mcp serve flags.
+// Order here determines the order of keys written to the config file.
+var ServeFlags = []FlagDef{
+	{
+		Name:     "transport",
+		ViperKey: "mcp.transport",
+		Default:  "stdio",
+		Usage:    "Transport protocol: stdio or http (env: SEER_MCP_TRANSPORT)",
+	},
+	{
+		Name:     "addr",
+		ViperKey: "mcp.addr",
+		Default:  ":8811",
+		Usage:    "HTTP bind address (http transport only) (env: SEER_MCP_ADDR)",
+	},
+	{
+		Name:     "auth-token",
+		ViperKey: "mcp.auth_token",
+		Default:  "",
+		Usage:    "Bearer token required for HTTP transport (env: SEER_MCP_AUTH_TOKEN)",
+	},
+	{
+		Name:     "no-auth",
+		ViperKey: "mcp.no_auth",
+		Default:  "false",
+		IsBool:   true,
+		Usage:    "Disable authentication (insecure — must be explicit) (env: SEER_MCP_NO_AUTH)",
+	},
+	{
+		Name:     "route-token",
+		ViperKey: "mcp.route_token",
+		Default:  "",
+		Usage:    "Secret path prefix for the MCP endpoint (e.g. 'abc123' → /abc123/mcp) (env: SEER_MCP_ROUTE_TOKEN)",
+	},
+	{
+		Name:     "tls-cert",
+		ViperKey: "mcp.tls_cert",
+		Default:  "",
+		Usage:    "Path to TLS certificate file (env: SEER_MCP_TLS_CERT)",
+	},
+	{
+		Name:     "tls-key",
+		ViperKey: "mcp.tls_key",
+		Default:  "",
+		Usage:    "Path to TLS private key file (env: SEER_MCP_TLS_KEY)",
+	},
+	{
+		Name:     "cors",
+		ViperKey: "mcp.cors",
+		Default:  "false",
+		IsBool:   true,
+		Usage:    "Enable CORS headers (required for browser-based clients such as claude.ai) (env: SEER_MCP_CORS)",
+	},
+	{
+		Name:     "multi-tenant",
+		ViperKey: "mcp.multi_tenant",
+		Default:  "false",
+		IsBool:   true,
+		Usage:    "Route /{seer-api-token}/mcp for per-user API keys (HTTP transport only)",
+	},
+	{
+		Name:     "log-file",
+		ViperKey: "mcp.log_file",
+		Default:  "",
+		Usage:    "Path to log file; required for stdio transport to capture logs (env: SEER_MCP_LOG_FILE)",
+	},
+	{
+		Name:     "log-level",
+		ViperKey: "mcp.log_level",
+		Default:  "info",
+		Usage:    "Log level: debug, info, warn, error (env: SEER_MCP_LOG_LEVEL)",
+	},
+	{
+		Name:     "log-format",
+		ViperKey: "mcp.log_format",
+		Default:  "text",
+		Usage:    "Log format: text or json (env: SEER_MCP_LOG_FORMAT)",
+	},
+}
+
+// RegisterFlags adds all MCP serve flags to cmd without binding them to Viper.
+// Safe to call on any command (serve, config set, etc.) without side effects.
+func RegisterFlags(cmd *cobra.Command) {
+	for _, f := range ServeFlags {
+		if f.IsBool {
+			cmd.Flags().Bool(f.Name, f.Default == "true", f.Usage)
+		} else {
+			cmd.Flags().String(f.Name, f.Default, f.Usage)
+		}
+	}
+}
+
+// BindFlags binds the flags already registered on cmd to their Viper keys.
+// Must only be called from the serve command so that config set does not
+// overwrite the serve command's Viper bindings with unparsed flag values.
+func BindFlags(cmd *cobra.Command) {
+	for _, f := range ServeFlags {
+		if flag := cmd.Flags().Lookup(f.Name); flag != nil {
+			viper.BindPFlag(f.ViperKey, flag)
+		}
+	}
+}

--- a/cmd/mcp/serve.go
+++ b/cmd/mcp/serve.go
@@ -44,30 +44,8 @@ var serveCmd = &cobra.Command{
 }
 
 func init() {
-	serveCmd.Flags().String("transport", "stdio", "Transport protocol: stdio or http (env: SEER_MCP_TRANSPORT)")
-	serveCmd.Flags().String("addr", ":8811", "HTTP bind address (http transport only) (env: SEER_MCP_ADDR)")
-	serveCmd.Flags().String("auth-token", "", "Bearer token required for HTTP transport (env: SEER_MCP_AUTH_TOKEN)")
-	serveCmd.Flags().Bool("no-auth", false, "Disable authentication (insecure — must be explicit) (env: SEER_MCP_NO_AUTH)")
-	serveCmd.Flags().String("route-token", "", "Secret path prefix for the MCP endpoint (e.g. 'abc123' → /abc123/mcp). Useful for clients that cannot send custom headers (env: SEER_MCP_ROUTE_TOKEN)")
-	serveCmd.Flags().String("tls-cert", "", "Path to TLS certificate file (env: SEER_MCP_TLS_CERT)")
-	serveCmd.Flags().String("tls-key", "", "Path to TLS private key file (env: SEER_MCP_TLS_KEY)")
-	serveCmd.Flags().Bool("cors", false, "Enable CORS headers (required for browser-based clients such as claude.ai) (env: SEER_MCP_CORS)")
-	serveCmd.Flags().Bool("multi-tenant", false, "Route /{seer-api-token}/mcp for per-user API keys (HTTP transport only)")
-	serveCmd.Flags().String("log-file", "", "Path to log file; required for stdio transport to capture logs (env: SEER_MCP_LOG_FILE)")
-	serveCmd.Flags().String("log-level", "info", "Log level: debug, info, warn, error (env: SEER_MCP_LOG_LEVEL)")
-	serveCmd.Flags().String("log-format", "text", "Log format: text or json (env: SEER_MCP_LOG_FORMAT)")
-	viper.BindPFlag("mcp.transport", serveCmd.Flags().Lookup("transport"))
-	viper.BindPFlag("mcp.addr", serveCmd.Flags().Lookup("addr"))
-	viper.BindPFlag("mcp.auth_token", serveCmd.Flags().Lookup("auth-token"))
-	viper.BindPFlag("mcp.no_auth", serveCmd.Flags().Lookup("no-auth"))
-	viper.BindPFlag("mcp.route_token", serveCmd.Flags().Lookup("route-token"))
-	viper.BindPFlag("mcp.tls_cert", serveCmd.Flags().Lookup("tls-cert"))
-	viper.BindPFlag("mcp.tls_key", serveCmd.Flags().Lookup("tls-key"))
-	viper.BindPFlag("mcp.cors", serveCmd.Flags().Lookup("cors"))
-	viper.BindPFlag("mcp.multi_tenant", serveCmd.Flags().Lookup("multi-tenant"))
-	viper.BindPFlag("mcp.log_file", serveCmd.Flags().Lookup("log-file"))
-	viper.BindPFlag("mcp.log_level", serveCmd.Flags().Lookup("log-level"))
-	viper.BindPFlag("mcp.log_format", serveCmd.Flags().Lookup("log-format"))
+	RegisterFlags(serveCmd)
+	BindFlags(serveCmd)
 	Cmd.AddCommand(serveCmd)
 }
 


### PR DESCRIPTION
## Summary

- Restructures `~/.seer-cli.yaml` from a flat layout to a two-section format (`seer:` and `mcp:`).
- Adds `seer-cli.schema.json` (JSON Schema draft-2020-12); every written config file includes a `yaml-language-server` comment pointing to it, giving IDEs autocomplete and validation.
- Empty values and settings that match their defaults are never written to the config file.
- `verbose` is no longer persisted — it's a per-invocation flag only.
- `config set` now accepts all MCP server flags (same as `mcp serve`) so users can configure the MCP server without editing YAML by hand.
- All MCP flag definitions live in one place (`cmd/mcp/flags.go`); adding a new flag in future requires touching only that file.

## Changes

- `seer-cli.schema.json` — new JSON Schema at repo root describing every valid config key.
- `cmd/mcp/flags.go` (**new**) — `ServeFlags []FlagDef` is the single source of truth for all MCP flags. `RegisterFlags(cmd)` and `BindFlags(cmd)` are the two exported helpers.
- `cmd/mcp/serve.go` — `init()` reduced to `RegisterFlags + BindFlags + AddCommand`.
- `cmd/config/set.go` — registers MCP flags via `mcp.RegisterFlags`; promotes changed flags to Viper; writes structured YAML via a dynamic `yaml.Node` builder driven by `ServeFlags + viper.IsSet()`. The hardcoded `mcpSection` struct and default-comparison logic are gone.
- `cmd/root.go` — Viper keys renamed (`server` → `seer.server`, `api_key` → `seer.api_key`); explicit `BindEnv` preserves env var compat (`SEER_SERVER`, `SEER_API_KEY`); key replacer extended to handle `.` → `_`.
- All `cmd/*/` packages and tests — updated Viper key names.

**Example output of `config set`:**
```yaml
# yaml-language-server: $schema=https://raw.githubusercontent.com/electather/seer-cli/main/seer-cli.schema.json
seer:
  server: https://seer.example.com
  api_key: abc123
mcp:
  transport: http
  auth_token: mysecret
  cors: true
```

## Test plan

- [ ] `go test -v ./...` passes.
- [ ] `go build` succeeds.
- [ ] `go fmt ./...` produces no diff.
- [ ] `seer-cli config set --server https://x.com --api-key k` → writes structured YAML with schema comment, no empty keys.
- [ ] `seer-cli config set --transport http --auth-token s --cors` → writes only the `mcp:` section.
- [ ] `seer-cli config set --help` shows all MCP flags.
- [ ] `SEER_SERVER=https://x.com SEER_API_KEY=k seer-cli status system` still works (env var compat).
- [ ] VS Code shows autocomplete for `seer.server`, `mcp.transport`, etc. when editing the config file.

## Checklist

- [x] Tests updated for new Viper key names
- [x] `gopkg.in/yaml.v3` promoted to direct dependency
- [x] No new external dependencies beyond yaml.v3
- [x] Backward-compatible env vars preserved