### PR TITLE
feat(mcp): add resources, prompts, and missing tools

### DIFF
--- a/cmd/mcp/prompts.go
+++ b/cmd/mcp/prompts.go
@@ -1,0 +1,318 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+func registerPrompts(s *server.MCPServer) {
+	s.AddPrompt(
+		mcp.NewPrompt("request_media",
+			mcp.WithPromptDescription("Request a movie or TV show to be downloaded. Use this when the user says 'I want to watch X' or asks to add something."),
+			mcp.WithArgument("title",
+				mcp.ArgumentDescription("The title of the movie or TV show to request"),
+				mcp.RequiredArgument(),
+			),
+			mcp.WithArgument("media_type",
+				mcp.ArgumentDescription("Media type: 'movie' or 'tv' (optional, will search both if omitted)"),
+			),
+			mcp.WithArgument("quality",
+				mcp.ArgumentDescription("Preferred quality: '4k' or 'hd' (optional)"),
+			),
+		),
+		RequestMediaPromptHandler(),
+	)
+
+	s.AddPrompt(
+		mcp.NewPrompt("discover_content",
+			mcp.WithPromptDescription("Find something to watch based on preferences or trending content."),
+			mcp.WithArgument("preferences",
+				mcp.ArgumentDescription("Optional mood, genre, or theme description (e.g. 'something funny' or 'sci-fi thriller')"),
+			),
+			mcp.WithArgument("media_type",
+				mcp.ArgumentDescription("Limit to 'movie' or 'tv' (optional)"),
+			),
+		),
+		DiscoverContentPromptHandler(),
+	)
+
+	s.AddPrompt(
+		mcp.NewPrompt("manage_requests",
+			mcp.WithPromptDescription("Admin dashboard for reviewing and actioning pending media requests."),
+			mcp.WithArgument("status",
+				mcp.ArgumentDescription("Filter by request status: pending, approved, available, failed (optional, defaults to pending)"),
+			),
+		),
+		ManageRequestsPromptHandler(),
+	)
+
+	s.AddPrompt(
+		mcp.NewPrompt("report_issue",
+			mcp.WithPromptDescription("Report a problem with a movie or TV show (e.g. wrong audio, missing subtitles, corrupt file)."),
+			mcp.WithArgument("media_title",
+				mcp.ArgumentDescription("The title of the media that has a problem"),
+				mcp.RequiredArgument(),
+			),
+			mcp.WithArgument("description",
+				mcp.ArgumentDescription("Optional description of the problem"),
+			),
+		),
+		ReportIssuePromptHandler(),
+	)
+
+	s.AddPrompt(
+		mcp.NewPrompt("my_dashboard",
+			mcp.WithPromptDescription("Show a personal overview: your active requests, quota usage, and recent activity."),
+		),
+		MyDashboardPromptHandler(),
+	)
+
+	s.AddPrompt(
+		mcp.NewPrompt("admin_overview",
+			mcp.WithPromptDescription("System health check: server status, pending requests, open issues, and scheduled jobs."),
+		),
+		AdminOverviewPromptHandler(),
+	)
+}
+
+// RequestMediaPromptHandler returns a prompt handler that guides the AI through
+// searching for media, checking availability, and creating a download request.
+func RequestMediaPromptHandler() server.PromptHandlerFunc {
+	return func(ctx context.Context, req mcp.GetPromptRequest) (*mcp.GetPromptResult, error) {
+		title := req.Params.Arguments["title"]
+		mediaType := req.Params.Arguments["media_type"]
+		quality := req.Params.Arguments["quality"]
+
+		instructions := fmt.Sprintf(`You are helping the user request media to be downloaded via Seerr.
+
+The user wants to watch: %q
+
+Follow these steps in order:
+
+1. Call search_multi with query=%q to find the title.
+2. Present the top 3 results to the user with title, year, and media type. Ask the user to confirm which one they want.
+3. Once confirmed, check the mediaInfo.status field on the result:
+   - If status is 5 (Available) or 4 (Partially Available), tell the user it is already available and no request is needed.
+   - If status is 3 (Processing) or 2 (Pending), tell the user a request is already in progress.
+4. If not available, call request_list to check whether an existing request already covers this media (match by mediaId).
+5. If no existing request, call request_create with:
+   - mediaType: %q (or as determined from search results if not specified)
+   - mediaId: the TMDB ID from the search result
+   - is4k: %v (true if quality is "4k", false otherwise)
+   Use the seerr://services/radarr or seerr://services/sonarr resource to find the appropriate server ID and quality profile if needed.
+6. Confirm the request was created and give the user the request ID.`,
+			title, title,
+			mediaTypeOrDefault(mediaType),
+			quality == "4k",
+		)
+
+		return &mcp.GetPromptResult{
+			Description: "Guide to request a movie or TV show for download",
+			Messages: []mcp.PromptMessage{
+				{
+					Role:    mcp.RoleUser,
+					Content: mcp.TextContent{Type: "text", Text: instructions},
+				},
+			},
+		}, nil
+	}
+}
+
+// DiscoverContentPromptHandler returns a prompt handler that guides the AI through
+// finding trending or genre-filtered content for the user.
+func DiscoverContentPromptHandler() server.PromptHandlerFunc {
+	return func(ctx context.Context, req mcp.GetPromptRequest) (*mcp.GetPromptResult, error) {
+		preferences := req.Params.Arguments["preferences"]
+		mediaType := req.Params.Arguments["media_type"]
+
+		var instructions string
+		if preferences != "" {
+			instructions = fmt.Sprintf(`You are helping the user discover content to watch.
+
+The user's preferences: %q
+
+Follow these steps:
+1. Read the seerr://genres/movies and seerr://genres/tv resources to find genre IDs that match the user's preferences.
+2. Based on the media type preference (%q), call search_discover_movies or search_discover_tv with a relevant genre filter.
+3. Also call search_trending to supplement with trending content.
+4. Present a curated list of 5-8 recommendations, including title, year, genre, and whether each is already Available in Seerr (check mediaInfo.status == 5).
+5. Ask the user if they would like to request any of the shown titles.`,
+				preferences, mediaTypeOrDefault(mediaType))
+		} else {
+			instructions = fmt.Sprintf(`You are helping the user discover content to watch.
+
+Follow these steps:
+1. Call search_trending to get currently popular content.
+2. Based on the media type preference (%q), optionally also call search_discover_movies or search_discover_tv for additional variety.
+3. Present a curated list of 5-8 recommendations with title, year, and whether each is Available (mediaInfo.status == 5).
+4. Ask the user if they would like to request any of the shown titles.`,
+				mediaTypeOrDefault(mediaType))
+		}
+
+		return &mcp.GetPromptResult{
+			Description: "Guide to discover trending or genre-filtered content",
+			Messages: []mcp.PromptMessage{
+				{
+					Role:    mcp.RoleUser,
+					Content: mcp.TextContent{Type: "text", Text: instructions},
+				},
+			},
+		}, nil
+	}
+}
+
+// ManageRequestsPromptHandler returns a prompt handler that guides an admin through
+// reviewing and bulk-actioning pending media requests.
+func ManageRequestsPromptHandler() server.PromptHandlerFunc {
+	return func(ctx context.Context, req mcp.GetPromptRequest) (*mcp.GetPromptResult, error) {
+		status := req.Params.Arguments["status"]
+		if status == "" {
+			status = "pending"
+		}
+
+		instructions := fmt.Sprintf(`You are helping an admin review and action media requests in Seerr.
+
+Status filter: %q
+
+Follow these steps:
+1. Call request_count to get a summary of all request statuses.
+2. Call request_list with filter=%q to retrieve the relevant requests.
+3. Group the results by media type (movie vs TV show).
+4. For each request, display: title, requester, requested date, and current status.
+5. Ask the admin whether they want to approve, decline, or skip each request (or handle them in bulk).
+6. For each decision, call request_approve or request_decline with the appropriate requestId.
+7. Summarise the actions taken at the end.`,
+			status, status)
+
+		return &mcp.GetPromptResult{
+			Description: "Admin workflow to review and action pending media requests",
+			Messages: []mcp.PromptMessage{
+				{
+					Role:    mcp.RoleUser,
+					Content: mcp.TextContent{Type: "text", Text: instructions},
+				},
+			},
+		}, nil
+	}
+}
+
+// ReportIssuePromptHandler returns a prompt handler that guides the user through
+// searching for media and filing an issue report.
+func ReportIssuePromptHandler() server.PromptHandlerFunc {
+	return func(ctx context.Context, req mcp.GetPromptRequest) (*mcp.GetPromptResult, error) {
+		mediaTitle := req.Params.Arguments["media_title"]
+		description := req.Params.Arguments["description"]
+
+		descriptionLine := ""
+		if description != "" {
+			descriptionLine = fmt.Sprintf("\nThe user has described the problem as: %q\n", description)
+		}
+
+		instructions := fmt.Sprintf(`You are helping the user report a problem with media in Seerr.
+
+The user has an issue with: %q%s
+Follow these steps:
+1. Call search_multi with query=%q to find the media.
+2. Present the top matches and ask the user to confirm which one has the problem.
+3. Ask the user what type of problem they are experiencing:
+   - 1: Video quality issue
+   - 2: Audio quality issue
+   - 3: Subtitle issue
+   - 4: Wrong content (wrong episode, wrong cut, etc.)
+   - 5: Other
+4. If no description was provided, ask the user to describe the problem briefly.
+5. Call issue_create with:
+   - mediaType: the type from search results
+   - mediaId: the TMDB ID
+   - issueType: the number selected above (1-5)
+   - message: the problem description
+6. Confirm the issue was filed and provide the issue ID.`,
+			mediaTitle, descriptionLine, mediaTitle)
+
+		return &mcp.GetPromptResult{
+			Description: "Guide to report a playback or content issue with media",
+			Messages: []mcp.PromptMessage{
+				{
+					Role:    mcp.RoleUser,
+					Content: mcp.TextContent{Type: "text", Text: instructions},
+				},
+			},
+		}, nil
+	}
+}
+
+// MyDashboardPromptHandler returns a prompt handler that presents a personalised
+// overview of the current user's requests and quota.
+func MyDashboardPromptHandler() server.PromptHandlerFunc {
+	return func(ctx context.Context, req mcp.GetPromptRequest) (*mcp.GetPromptResult, error) {
+		instructions := `You are presenting a personal Seerr dashboard for the current user.
+
+Follow these steps:
+1. Call auth_me to get the current user's profile, ID, and permissions.
+2. In parallel:
+   a. Call request_list filtered to the current user's requests (match requestedBy.id from auth_me).
+   b. Call users_quota with the user's ID to check their remaining request quota.
+3. Present a summary including:
+   - User name, email, and role
+   - Number of active requests (pending/processing) vs completed
+   - Quota remaining (movie requests and TV show requests)
+   - Any requests that are in a failed or unavailable state, with a note to retry or report an issue
+4. Ask if the user would like to take any action (e.g. make a new request, report an issue, or retry a failed request).`
+
+		return &mcp.GetPromptResult{
+			Description: "Personal Seerr dashboard showing requests and quota",
+			Messages: []mcp.PromptMessage{
+				{
+					Role:    mcp.RoleUser,
+					Content: mcp.TextContent{Type: "text", Text: instructions},
+				},
+			},
+		}, nil
+	}
+}
+
+// AdminOverviewPromptHandler returns a prompt handler that presents a system-wide
+// health check for Seerr administrators.
+func AdminOverviewPromptHandler() server.PromptHandlerFunc {
+	return func(ctx context.Context, req mcp.GetPromptRequest) (*mcp.GetPromptResult, error) {
+		instructions := `You are presenting a system health overview for a Seerr administrator.
+
+Follow these steps (run all calls in parallel where possible):
+1. Call status_system to get system health and version information.
+2. Call request_count to get the breakdown of requests by status.
+3. Call issue_count to get the count of open issues.
+4. Call settings_jobs_list to see scheduled job statuses.
+
+Present a structured summary:
+- System Status: version, whether an update is available, any warnings
+- Requests: total pending, processing, failed — highlight any that need attention
+- Issues: total open issues — note if there are unresolved issues older than 7 days
+- Scheduled Jobs: list any jobs that are currently running or recently failed
+
+Finally, ask the admin if they want to take any action, such as:
+- Approving or declining pending requests (use manage_requests prompt)
+- Reviewing open issues
+- Triggering a scheduled job manually (settings_jobs_run)`
+
+		return &mcp.GetPromptResult{
+			Description: "System health check for Seerr administrators",
+			Messages: []mcp.PromptMessage{
+				{
+					Role:    mcp.RoleUser,
+					Content: mcp.TextContent{Type: "text", Text: instructions},
+				},
+			},
+		}, nil
+	}
+}
+
+// mediaTypeOrDefault returns the provided media type string, or "movie or tv" if empty.
+func mediaTypeOrDefault(mediaType string) string {
+	if mediaType == "" {
+		return "movie or tv"
+	}
+	return mediaType
+}

--- a/cmd/mcp/resources.go
+++ b/cmd/mcp/resources.go
@@ -1,0 +1,357 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+
+	api "seerr-cli/pkg/api"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+func registerResources(s *server.MCPServer) {
+	s.AddResource(
+		mcp.NewResource("seerr://genres/movies", "Movie Genres",
+			mcp.WithResourceDescription("TMDB movie genre ID to name map"),
+			mcp.WithMIMEType("application/json"),
+		),
+		GenresMovieResourceHandler(),
+	)
+
+	s.AddResource(
+		mcp.NewResource("seerr://genres/tv", "TV Genres",
+			mcp.WithResourceDescription("TMDB TV genre ID to name map"),
+			mcp.WithMIMEType("application/json"),
+		),
+		GenresTVResourceHandler(),
+	)
+
+	s.AddResource(
+		mcp.NewResource("seerr://languages", "Languages",
+			mcp.WithResourceDescription("ISO language codes and English names supported by TMDB"),
+			mcp.WithMIMEType("application/json"),
+		),
+		LanguagesResourceHandler(),
+	)
+
+	s.AddResource(
+		mcp.NewResource("seerr://regions", "Regions",
+			mcp.WithResourceDescription("ISO region codes and English names supported by TMDB"),
+			mcp.WithMIMEType("application/json"),
+		),
+		RegionsResourceHandler(),
+	)
+
+	s.AddResource(
+		mcp.NewResource("seerr://certifications/movies", "Movie Certifications",
+			mcp.WithResourceDescription("Content ratings by country for movies (G, PG, R, etc.)"),
+			mcp.WithMIMEType("application/json"),
+		),
+		CertificationsMovieResourceHandler(),
+	)
+
+	s.AddResource(
+		mcp.NewResource("seerr://certifications/tv", "TV Certifications",
+			mcp.WithResourceDescription("Content ratings by country for TV shows"),
+			mcp.WithMIMEType("application/json"),
+		),
+		CertificationsTVResourceHandler(),
+	)
+
+	s.AddResource(
+		mcp.NewResource("seerr://services/radarr", "Radarr Services",
+			mcp.WithResourceDescription("Configured Radarr instances with quality profiles and root folders"),
+			mcp.WithMIMEType("application/json"),
+		),
+		RadarrServicesResourceHandler(),
+	)
+
+	s.AddResource(
+		mcp.NewResource("seerr://services/sonarr", "Sonarr Services",
+			mcp.WithResourceDescription("Configured Sonarr instances with quality profiles and root folders"),
+			mcp.WithMIMEType("application/json"),
+		),
+		SonarrServicesResourceHandler(),
+	)
+
+	s.AddResource(
+		mcp.NewResource("seerr://system/about", "System Info",
+			mcp.WithResourceDescription("Seerr version, commit hash, and update availability"),
+			mcp.WithMIMEType("application/json"),
+		),
+		SystemAboutResourceHandler(),
+	)
+}
+
+// textResource wraps JSON bytes as a single TextResourceContents slice.
+func textResource(uri string, data []byte) []mcp.ResourceContents {
+	return []mcp.ResourceContents{mcp.TextResourceContents{
+		URI:      uri,
+		MIMEType: "application/json",
+		Text:     string(data),
+	}}
+}
+
+// GenresMovieResourceHandler returns a resource handler for the TMDB movie genre list.
+func GenresMovieResourceHandler() server.ResourceHandlerFunc {
+	return func(ctx context.Context, req mcp.ReadResourceRequest) ([]mcp.ResourceContents, error) {
+		client := newAPIClientWithKey(apiKeyFromContext(ctx))
+		res, _, err := client.TmdbAPI.GenresMovieGet(ctx).Execute()
+		if err != nil {
+			return nil, err
+		}
+		data, err := json.MarshalIndent(res, "", "  ")
+		if err != nil {
+			return nil, err
+		}
+		return textResource(req.Params.URI, data), nil
+	}
+}
+
+// GenresTVResourceHandler returns a resource handler for the TMDB TV genre list.
+func GenresTVResourceHandler() server.ResourceHandlerFunc {
+	return func(ctx context.Context, req mcp.ReadResourceRequest) ([]mcp.ResourceContents, error) {
+		client := newAPIClientWithKey(apiKeyFromContext(ctx))
+		res, _, err := client.TmdbAPI.GenresTvGet(ctx).Execute()
+		if err != nil {
+			return nil, err
+		}
+		data, err := json.MarshalIndent(res, "", "  ")
+		if err != nil {
+			return nil, err
+		}
+		return textResource(req.Params.URI, data), nil
+	}
+}
+
+// LanguagesResourceHandler returns a resource handler for the TMDB language list.
+func LanguagesResourceHandler() server.ResourceHandlerFunc {
+	return func(ctx context.Context, req mcp.ReadResourceRequest) ([]mcp.ResourceContents, error) {
+		client := newAPIClientWithKey(apiKeyFromContext(ctx))
+		res, _, err := client.TmdbAPI.LanguagesGet(ctx).Execute()
+		if err != nil {
+			return nil, err
+		}
+		data, err := json.MarshalIndent(res, "", "  ")
+		if err != nil {
+			return nil, err
+		}
+		return textResource(req.Params.URI, data), nil
+	}
+}
+
+// RegionsResourceHandler returns a resource handler for the TMDB region list.
+func RegionsResourceHandler() server.ResourceHandlerFunc {
+	return func(ctx context.Context, req mcp.ReadResourceRequest) ([]mcp.ResourceContents, error) {
+		client := newAPIClientWithKey(apiKeyFromContext(ctx))
+		res, _, err := client.TmdbAPI.RegionsGet(ctx).Execute()
+		if err != nil {
+			return nil, err
+		}
+		data, err := json.MarshalIndent(res, "", "  ")
+		if err != nil {
+			return nil, err
+		}
+		return textResource(req.Params.URI, data), nil
+	}
+}
+
+// CertificationsMovieResourceHandler returns a resource handler for movie content ratings.
+func CertificationsMovieResourceHandler() server.ResourceHandlerFunc {
+	return func(ctx context.Context, req mcp.ReadResourceRequest) ([]mcp.ResourceContents, error) {
+		client := newAPIClientWithKey(apiKeyFromContext(ctx))
+		res, _, err := client.OtherAPI.CertificationsMovieGet(ctx).Execute()
+		if err != nil {
+			return nil, err
+		}
+		data, err := json.MarshalIndent(res, "", "  ")
+		if err != nil {
+			return nil, err
+		}
+		return textResource(req.Params.URI, data), nil
+	}
+}
+
+// CertificationsTVResourceHandler returns a resource handler for TV content ratings.
+func CertificationsTVResourceHandler() server.ResourceHandlerFunc {
+	return func(ctx context.Context, req mcp.ReadResourceRequest) ([]mcp.ResourceContents, error) {
+		client := newAPIClientWithKey(apiKeyFromContext(ctx))
+		res, _, err := client.OtherAPI.CertificationsTvGet(ctx).Execute()
+		if err != nil {
+			return nil, err
+		}
+		data, err := json.MarshalIndent(res, "", "  ")
+		if err != nil {
+			return nil, err
+		}
+		return textResource(req.Params.URI, data), nil
+	}
+}
+
+// WatchProvidersMoviesResourceHandler returns a resource handler for movie streaming providers.
+func WatchProvidersMoviesResourceHandler() server.ResourceHandlerFunc {
+	return func(ctx context.Context, req mcp.ReadResourceRequest) ([]mcp.ResourceContents, error) {
+		client := newAPIClientWithKey(apiKeyFromContext(ctx))
+		res, _, err := client.OtherAPI.WatchprovidersMoviesGet(ctx).Execute()
+		if err != nil {
+			return nil, err
+		}
+		data, err := json.MarshalIndent(res, "", "  ")
+		if err != nil {
+			return nil, err
+		}
+		return textResource(req.Params.URI, data), nil
+	}
+}
+
+// WatchProvidersTVResourceHandler returns a resource handler for TV streaming providers.
+func WatchProvidersTVResourceHandler() server.ResourceHandlerFunc {
+	return func(ctx context.Context, req mcp.ReadResourceRequest) ([]mcp.ResourceContents, error) {
+		client := newAPIClientWithKey(apiKeyFromContext(ctx))
+		res, _, err := client.OtherAPI.WatchprovidersTvGet(ctx).Execute()
+		if err != nil {
+			return nil, err
+		}
+		data, err := json.MarshalIndent(res, "", "  ")
+		if err != nil {
+			return nil, err
+		}
+		return textResource(req.Params.URI, data), nil
+	}
+}
+
+// RadarrServicesResourceHandler returns a resource handler that lists all configured
+// Radarr instances enriched with per-instance quality profiles and root folders.
+func RadarrServicesResourceHandler() server.ResourceHandlerFunc {
+	return func(ctx context.Context, req mcp.ReadResourceRequest) ([]mcp.ResourceContents, error) {
+		client := newAPIClientWithKey(apiKeyFromContext(ctx))
+		instances, _, err := client.ServiceAPI.ServiceRadarrGet(ctx).Execute()
+		if err != nil {
+			return nil, err
+		}
+		enriched := enrichRadarrInstances(ctx, client, instances)
+		data, err := json.MarshalIndent(enriched, "", "  ")
+		if err != nil {
+			return nil, err
+		}
+		return textResource(req.Params.URI, data), nil
+	}
+}
+
+// SonarrServicesResourceHandler returns a resource handler that lists all configured
+// Sonarr instances enriched with per-instance quality profiles and root folders.
+func SonarrServicesResourceHandler() server.ResourceHandlerFunc {
+	return func(ctx context.Context, req mcp.ReadResourceRequest) ([]mcp.ResourceContents, error) {
+		client := newAPIClientWithKey(apiKeyFromContext(ctx))
+		instances, _, err := client.ServiceAPI.ServiceSonarrGet(ctx).Execute()
+		if err != nil {
+			return nil, err
+		}
+		enriched := enrichSonarrInstances(ctx, client, instances)
+		data, err := json.MarshalIndent(enriched, "", "  ")
+		if err != nil {
+			return nil, err
+		}
+		return textResource(req.Params.URI, data), nil
+	}
+}
+
+// SystemAboutResourceHandler returns a resource handler for Seerr system information.
+func SystemAboutResourceHandler() server.ResourceHandlerFunc {
+	return func(ctx context.Context, req mcp.ReadResourceRequest) ([]mcp.ResourceContents, error) {
+		client := newAPIClientWithKey(apiKeyFromContext(ctx))
+		res, _, err := client.SettingsAPI.SettingsAboutGet(ctx).Execute()
+		if err != nil {
+			return nil, err
+		}
+		data, err := json.MarshalIndent(res, "", "  ")
+		if err != nil {
+			return nil, err
+		}
+		return textResource(req.Params.URI, data), nil
+	}
+}
+
+// enrichRadarrInstances fetches per-instance details for each Radarr entry concurrently
+// and returns the enriched list. Instances without an ID fall back to the basic settings.
+func enrichRadarrInstances(ctx context.Context, client *api.APIClient, instances []api.RadarrSettings) []interface{} {
+	type detailResult struct {
+		idx    int
+		detail interface{}
+	}
+	ch := make(chan detailResult, len(instances))
+	var wg sync.WaitGroup
+	for i, inst := range instances {
+		if !inst.HasId() {
+			continue
+		}
+		wg.Add(1)
+		go func(i int, id float32) {
+			defer wg.Done()
+			detail, _, err := client.ServiceAPI.ServiceRadarrRadarrIdGet(ctx, id).Execute()
+			if err == nil {
+				ch <- detailResult{idx: i, detail: detail}
+			}
+		}(i, inst.GetId())
+	}
+	wg.Wait()
+	close(ch)
+
+	detailsMap := make(map[int]interface{})
+	for r := range ch {
+		detailsMap[r.idx] = r.detail
+	}
+
+	result := make([]interface{}, len(instances))
+	for i, inst := range instances {
+		if d, ok := detailsMap[i]; ok {
+			result[i] = d
+		} else {
+			result[i] = inst
+		}
+	}
+	return result
+}
+
+// enrichSonarrInstances fetches per-instance details for each Sonarr entry concurrently
+// and returns the enriched list. Instances without an ID fall back to the basic settings.
+func enrichSonarrInstances(ctx context.Context, client *api.APIClient, instances []api.SonarrSettings) []interface{} {
+	type detailResult struct {
+		idx    int
+		detail interface{}
+	}
+	ch := make(chan detailResult, len(instances))
+	var wg sync.WaitGroup
+	for i, inst := range instances {
+		if !inst.HasId() {
+			continue
+		}
+		wg.Add(1)
+		go func(i int, id float32) {
+			defer wg.Done()
+			detail, _, err := client.ServiceAPI.ServiceSonarrSonarrIdGet(ctx, id).Execute()
+			if err == nil {
+				ch <- detailResult{idx: i, detail: detail}
+			}
+		}(i, inst.GetId())
+	}
+	wg.Wait()
+	close(ch)
+
+	detailsMap := make(map[int]interface{})
+	for r := range ch {
+		detailsMap[r.idx] = r.detail
+	}
+
+	result := make([]interface{}, len(instances))
+	for i, inst := range instances {
+		if d, ok := detailsMap[i]; ok {
+			result[i] = d
+		} else {
+			result[i] = inst
+		}
+	}
+	return result
+}

--- a/cmd/mcp/serve.go
+++ b/cmd/mcp/serve.go
@@ -99,6 +99,9 @@ func runServe(_ *cobra.Command, args []string) error {
 	registerSettingsTools(s)
 	registerWatchlistTools(s)
 	registerBlocklistTools(s)
+	registerAuthTools(s)
+	registerResources(s)
+	registerPrompts(s)
 
 	seerServer := viper.GetString("seerr.server")
 
@@ -107,7 +110,7 @@ func runServe(_ *cobra.Command, args []string) error {
 		mcpLog.Info("starting MCP server",
 			"transport", "stdio",
 			"seerr_api", seerServer,
-			"tools", 44,
+			"tools", 46, "resources", 9, "prompts", 6,
 		)
 		mcpLog.Debug("stdio transport ready, waiting for MCP client on stdin")
 		return server.ServeStdio(s)
@@ -133,7 +136,7 @@ func runServe(_ *cobra.Command, args []string) error {
 			"transport", "http",
 			"endpoint", endpoint,
 			"seerr_api", seerServer,
-			"tools", 44,
+			"tools", 46, "resources", 9, "prompts", 6,
 			"tls", tlsCert != "",
 			"auth_token", authToken != "",
 			"route_token", routeToken != "",

--- a/cmd/mcp/tools_auth.go
+++ b/cmd/mcp/tools_auth.go
@@ -1,0 +1,35 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+func registerAuthTools(s *server.MCPServer) {
+	s.AddTool(
+		mcp.NewTool("auth_me",
+			mcp.WithDescription("Get the currently authenticated user's profile, permissions, and quota"),
+			mcp.WithReadOnlyHintAnnotation(true),
+		),
+		AuthMeHandler(),
+	)
+}
+
+// AuthMeHandler returns a tool handler for GET /auth/me.
+func AuthMeHandler() server.ToolHandlerFunc {
+	return func(callCtx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		client := newAPIClientWithKey(apiKeyFromContext(callCtx))
+		res, _, err := client.AuthAPI.AuthMeGet(callCtx).Execute()
+		if err != nil {
+			return apiToolError("AuthMeGet failed", err)
+		}
+		b, err := json.Marshal(res)
+		if err != nil {
+			return nil, err
+		}
+		return mcp.NewToolResultText(string(b)), nil
+	}
+}

--- a/cmd/mcp/tools_request.go
+++ b/cmd/mcp/tools_request.go
@@ -70,6 +70,14 @@ func registerRequestTools(s *server.MCPServer) {
 		),
 		RequestCountHandler(),
 	)
+
+	s.AddTool(
+		mcp.NewTool("request_retry",
+			mcp.WithDescription("Retry a failed media request download"),
+			mcp.WithString("requestId", mcp.Required(), mcp.Description("Request ID")),
+		),
+		RequestRetryHandler(),
+	)
 }
 
 func RequestListHandler() server.ToolHandlerFunc {
@@ -196,6 +204,25 @@ func RequestDeleteHandler() server.ToolHandlerFunc {
 			return apiToolError("RequestRequestIdDelete failed", err)
 		}
 		return mcp.NewToolResultText(`{"status":"ok"}`), nil
+	}
+}
+
+func RequestRetryHandler() server.ToolHandlerFunc {
+	return func(callCtx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		requestId, err := req.RequireString("requestId")
+		if err != nil {
+			return nil, err
+		}
+		client := newAPIClientWithKey(apiKeyFromContext(callCtx))
+		res, _, err := client.RequestAPI.RequestRequestIdRetryPost(callCtx, requestId).Execute()
+		if err != nil {
+			return apiToolError("RequestRequestIdRetryPost failed", err)
+		}
+		b, err := json.Marshal(res)
+		if err != nil {
+			return nil, err
+		}
+		return mcp.NewToolResultText(string(b)), nil
 	}
 }
 

--- a/tests/mcp_auth_test.go
+++ b/tests/mcp_auth_test.go
@@ -1,0 +1,46 @@
+package tests
+
+import (
+	"net/http"
+	"testing"
+
+	cmdmcp "seerr-cli/cmd/mcp"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMCPAuthMeHandler(t *testing.T) {
+	_, cleanup := newMCPTestServer(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v1/auth/me" {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`{"id":1,"email":"admin@example.com","username":"admin","permissions":2}`))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	})
+	defer cleanup()
+
+	result := callTool(t, cmdmcp.AuthMeHandler(), nil)
+	text := resultText(t, result)
+
+	assert.Contains(t, text, `"id"`)
+	assert.Contains(t, text, `"email"`)
+	assert.Contains(t, text, `"admin@example.com"`)
+}
+
+func TestMCPRequestRetryHandler(t *testing.T) {
+	_, cleanup := newMCPTestServer(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v1/request/42/retry" && r.Method == http.MethodPost {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`{"id":42,"status":1,"type":"movie"}`))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	})
+	defer cleanup()
+
+	result := callTool(t, cmdmcp.RequestRetryHandler(), map[string]any{"requestId": "42"})
+	text := resultText(t, result)
+
+	assert.Contains(t, text, `"id"`)
+}

--- a/tests/mcp_prompts_test.go
+++ b/tests/mcp_prompts_test.go
@@ -1,0 +1,137 @@
+package tests
+
+import (
+	"context"
+	"testing"
+
+	cmdmcp "seerr-cli/cmd/mcp"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// callPrompt invokes a prompt handler and returns the GetPromptResult.
+func callPrompt(t *testing.T, handler func(context.Context, mcp.GetPromptRequest) (*mcp.GetPromptResult, error), args map[string]string) *mcp.GetPromptResult {
+	t.Helper()
+	req := mcp.GetPromptRequest{}
+	req.Params.Arguments = args
+	result, err := handler(context.Background(), req)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	return result
+}
+
+// promptText returns the text content of the first prompt message.
+func promptText(t *testing.T, result *mcp.GetPromptResult) string {
+	t.Helper()
+	require.NotEmpty(t, result.Messages, "expected at least one message")
+	content, ok := result.Messages[0].Content.(mcp.TextContent)
+	require.True(t, ok, "expected TextContent in first message")
+	return content.Text
+}
+
+func TestMCPRequestMediaPrompt(t *testing.T) {
+	result := callPrompt(t, cmdmcp.RequestMediaPromptHandler(), map[string]string{
+		"title": "Inception",
+	})
+
+	assert.NotEmpty(t, result.Description)
+	text := promptText(t, result)
+	assert.Contains(t, text, "Inception")
+	assert.Contains(t, text, "search_multi")
+	assert.Contains(t, text, "request_create")
+	assert.Equal(t, mcp.RoleUser, result.Messages[0].Role)
+}
+
+func TestMCPRequestMediaPromptWith4K(t *testing.T) {
+	result := callPrompt(t, cmdmcp.RequestMediaPromptHandler(), map[string]string{
+		"title":      "Dune",
+		"media_type": "movie",
+		"quality":    "4k",
+	})
+
+	text := promptText(t, result)
+	assert.Contains(t, text, "Dune")
+	assert.Contains(t, text, "true") // is4k should be true
+}
+
+func TestMCPDiscoverContentPromptNoPreferences(t *testing.T) {
+	result := callPrompt(t, cmdmcp.DiscoverContentPromptHandler(), nil)
+
+	assert.NotEmpty(t, result.Description)
+	text := promptText(t, result)
+	assert.Contains(t, text, "search_trending")
+}
+
+func TestMCPDiscoverContentPromptWithPreferences(t *testing.T) {
+	result := callPrompt(t, cmdmcp.DiscoverContentPromptHandler(), map[string]string{
+		"preferences": "action thriller",
+		"media_type":  "movie",
+	})
+
+	text := promptText(t, result)
+	assert.Contains(t, text, "action thriller")
+	assert.Contains(t, text, "seerr://genres")
+}
+
+func TestMCPManageRequestsPromptDefaultStatus(t *testing.T) {
+	result := callPrompt(t, cmdmcp.ManageRequestsPromptHandler(), nil)
+
+	text := promptText(t, result)
+	assert.Contains(t, text, "request_count")
+	assert.Contains(t, text, "pending")
+	assert.Contains(t, text, "request_approve")
+	assert.Contains(t, text, "request_decline")
+}
+
+func TestMCPManageRequestsPromptCustomStatus(t *testing.T) {
+	result := callPrompt(t, cmdmcp.ManageRequestsPromptHandler(), map[string]string{
+		"status": "failed",
+	})
+
+	text := promptText(t, result)
+	assert.Contains(t, text, "failed")
+}
+
+func TestMCPReportIssuePrompt(t *testing.T) {
+	result := callPrompt(t, cmdmcp.ReportIssuePromptHandler(), map[string]string{
+		"media_title": "Breaking Bad",
+	})
+
+	assert.NotEmpty(t, result.Description)
+	text := promptText(t, result)
+	assert.Contains(t, text, "Breaking Bad")
+	assert.Contains(t, text, "search_multi")
+	assert.Contains(t, text, "issue_create")
+}
+
+func TestMCPReportIssuePromptWithDescription(t *testing.T) {
+	result := callPrompt(t, cmdmcp.ReportIssuePromptHandler(), map[string]string{
+		"media_title": "The Wire",
+		"description": "Audio is out of sync",
+	})
+
+	text := promptText(t, result)
+	assert.Contains(t, text, "Audio is out of sync")
+}
+
+func TestMCPMyDashboardPrompt(t *testing.T) {
+	result := callPrompt(t, cmdmcp.MyDashboardPromptHandler(), nil)
+
+	assert.NotEmpty(t, result.Description)
+	text := promptText(t, result)
+	assert.Contains(t, text, "auth_me")
+	assert.Contains(t, text, "users_quota")
+}
+
+func TestMCPAdminOverviewPrompt(t *testing.T) {
+	result := callPrompt(t, cmdmcp.AdminOverviewPromptHandler(), nil)
+
+	assert.NotEmpty(t, result.Description)
+	text := promptText(t, result)
+	assert.Contains(t, text, "status_system")
+	assert.Contains(t, text, "request_count")
+	assert.Contains(t, text, "issue_count")
+	assert.Contains(t, text, "settings_jobs_list")
+}

--- a/tests/mcp_resources_test.go
+++ b/tests/mcp_resources_test.go
@@ -1,0 +1,173 @@
+package tests
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	cmdmcp "seerr-cli/cmd/mcp"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// callResource invokes a resource handler and returns the text of the first result.
+func callResource(t *testing.T, handler func(context.Context, mcp.ReadResourceRequest) ([]mcp.ResourceContents, error), uri string) string {
+	t.Helper()
+	req := mcp.ReadResourceRequest{}
+	req.Params.URI = uri
+	contents, err := handler(context.Background(), req)
+	require.NoError(t, err)
+	require.NotEmpty(t, contents)
+	text, ok := contents[0].(mcp.TextResourceContents)
+	require.True(t, ok, "expected TextResourceContents")
+	return text.Text
+}
+
+func TestMCPGenresMovieResource(t *testing.T) {
+	_, cleanup := newMCPTestServer(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v1/genres/movie" {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`[{"id":28,"name":"Action"},{"id":12,"name":"Adventure"}]`))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	})
+	defer cleanup()
+
+	text := callResource(t, cmdmcp.GenresMovieResourceHandler(), "seerr://genres/movies")
+	assert.Contains(t, text, `"Action"`)
+	assert.Contains(t, text, `"Adventure"`)
+}
+
+func TestMCPGenresTVResource(t *testing.T) {
+	_, cleanup := newMCPTestServer(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v1/genres/tv" {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`[{"id":10765,"name":"Sci-Fi & Fantasy"},{"id":18,"name":"Drama"}]`))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	})
+	defer cleanup()
+
+	text := callResource(t, cmdmcp.GenresTVResourceHandler(), "seerr://genres/tv")
+	assert.Contains(t, text, `"Drama"`)
+}
+
+func TestMCPLanguagesResource(t *testing.T) {
+	_, cleanup := newMCPTestServer(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v1/languages" {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`[{"iso_639_1":"en","english_name":"English"},{"iso_639_1":"fr","english_name":"French"}]`))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	})
+	defer cleanup()
+
+	text := callResource(t, cmdmcp.LanguagesResourceHandler(), "seerr://languages")
+	assert.Contains(t, text, `"English"`)
+	assert.Contains(t, text, `"French"`)
+}
+
+func TestMCPRegionsResource(t *testing.T) {
+	_, cleanup := newMCPTestServer(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v1/regions" {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`[{"iso_3166_1":"US","english_name":"United States"},{"iso_3166_1":"GB","english_name":"United Kingdom"}]`))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	})
+	defer cleanup()
+
+	text := callResource(t, cmdmcp.RegionsResourceHandler(), "seerr://regions")
+	assert.Contains(t, text, `"United States"`)
+}
+
+func TestMCPCertificationsMovieResource(t *testing.T) {
+	_, cleanup := newMCPTestServer(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v1/certifications/movie" {
+			w.Header().Set("Content-Type", "application/json")
+			// The CertificationResponse struct wraps the map under a "certifications" key.
+			w.Write([]byte(`{"certifications":{"US":[{"certification":"PG-13","meaning":"Parents strongly cautioned","order":3}]}}`))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	})
+	defer cleanup()
+
+	text := callResource(t, cmdmcp.CertificationsMovieResourceHandler(), "seerr://certifications/movies")
+	assert.Contains(t, text, `"PG-13"`)
+}
+
+func TestMCPCertificationsTVResource(t *testing.T) {
+	_, cleanup := newMCPTestServer(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v1/certifications/tv" {
+			w.Header().Set("Content-Type", "application/json")
+			// The CertificationResponse struct wraps the map under a "certifications" key.
+			w.Write([]byte(`{"certifications":{"US":[{"certification":"TV-MA","meaning":"Mature audiences","order":6}]}}`))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	})
+	defer cleanup()
+
+	text := callResource(t, cmdmcp.CertificationsTVResourceHandler(), "seerr://certifications/tv")
+	assert.Contains(t, text, `"TV-MA"`)
+}
+
+func TestMCPRadarrServicesResourceEnriched(t *testing.T) {
+	_, cleanup := newMCPTestServer(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/v1/service/radarr":
+			w.Write([]byte(`[{"id":1,"name":"Radarr HD","hostname":"radarr","port":7878,"apiKey":"key","useSsl":false,"activeProfileId":1,"activeProfileName":"HD-1080p","activeDirectory":"/movies","is4k":false,"minimumAvailability":"released","isDefault":true}]`))
+		case "/api/v1/service/radarr/1":
+			w.Write([]byte(`{"server":{"id":1,"name":"Radarr HD","hostname":"radarr","port":7878,"apiKey":"key","useSsl":false,"activeProfileId":1,"activeProfileName":"HD-1080p","activeDirectory":"/movies","is4k":false,"minimumAvailability":"released","isDefault":true},"profiles":{"qualityProfiles":[{"id":1,"name":"HD-1080p"}],"rootFolders":[{"id":1,"path":"/movies"}]}}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+	defer cleanup()
+
+	text := callResource(t, cmdmcp.RadarrServicesResourceHandler(), "seerr://services/radarr")
+	assert.Contains(t, text, `"profiles"`)
+	assert.Contains(t, text, `"HD-1080p"`)
+}
+
+func TestMCPSonarrServicesResourceEnriched(t *testing.T) {
+	_, cleanup := newMCPTestServer(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/v1/service/sonarr":
+			w.Write([]byte(`[{"id":1,"name":"Sonarr","hostname":"sonarr","port":8989,"apiKey":"key","useSsl":false,"activeProfileId":1,"activeProfileName":"HD-1080p","activeDirectory":"/tv","is4k":false,"enableSeasonFolders":true,"isDefault":true}]`))
+		case "/api/v1/service/sonarr/1":
+			w.Write([]byte(`{"server":{"id":1,"name":"Sonarr","hostname":"sonarr","port":8989,"apiKey":"key","useSsl":false,"activeProfileId":1,"activeProfileName":"HD-1080p","activeDirectory":"/tv","is4k":false,"enableSeasonFolders":true,"isDefault":true},"profiles":{"qualityProfiles":[{"id":1,"name":"HD-1080p"}],"rootFolders":[{"id":1,"path":"/tv"}]}}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+	defer cleanup()
+
+	text := callResource(t, cmdmcp.SonarrServicesResourceHandler(), "seerr://services/sonarr")
+	assert.Contains(t, text, `"profiles"`)
+}
+
+func TestMCPSystemAboutResource(t *testing.T) {
+	_, cleanup := newMCPTestServer(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v1/settings/about" {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`{"version":"2.0.0","totalRequests":42}`))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	})
+	defer cleanup()
+
+	text := callResource(t, cmdmcp.SystemAboutResourceHandler(), "seerr://system/about")
+	assert.Contains(t, text, `"2.0.0"`)
+	assert.Contains(t, text, `"totalRequests"`)
+}


### PR DESCRIPTION
## Summary

- **9 MCP Resources** — URI-addressable reference data AI clients can pre-load without tool calls:
  - `seerr://genres/movies`, `seerr://genres/tv` — TMDB genre ID→name maps
  - `seerr://languages`, `seerr://regions` — ISO reference data
  - `seerr://certifications/movies`, `seerr://certifications/tv` — content ratings by country
  - `seerr://services/radarr`, `seerr://services/sonarr` — service configs enriched with per-instance quality profiles and root folders (fetched concurrently)
  - `seerr://system/about` — Seerr version and stats

- **6 MCP Prompts** — workflow templates for common user intents:
  - `request_media` — "I want to watch X": search → check availability → create request
  - `discover_content` — trending/genre-filtered recommendations
  - `manage_requests` — admin bulk approve/decline dashboard
  - `report_issue` — search → confirm → classify → file issue
  - `my_dashboard` — personal requests and quota overview
  - `admin_overview` — system health, pending work, open issues

- **2 new tools**:
  - `auth_me` — `GET /auth/me`: current user profile, permissions, and quota
  - `request_retry` — `POST /request/{id}/retry`: retry a failed download

Registered totals: **46 tools, 9 resources, 6 prompts**.

## Test plan

- [ ] `go build` compiles cleanly
- [ ] `go test -v ./tests/` — all tests pass (new: `TestMCPGenres*`, `TestMCPLanguages*`, `TestMCPRegions*`, `TestMCPCertifications*`, `TestMCPRadarr*`, `TestMCPSonarr*`, `TestMCPSystemAbout*`, `TestMCPAuthMe*`, `TestMCPRequestRetry*`, `TestMCPRequest*Prompt`, `TestMCPDiscover*Prompt`, `TestMCPManage*Prompt`, `TestMCPReport*Prompt`, `TestMCPMyDashboard*`, `TestMCPAdminOverview*`)
- [ ] `go fmt ./...` — no changes
- [ ] `go vet ./...` — no issues