### PR TITLE
feat(docker): add OCI image labels to published Docker images

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -171,6 +171,10 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Generate image metadata
+        id: meta
+        run: echo "created=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
+
       - name: Build and push by digest
         id: build
         uses: docker/build-push-action@v6
@@ -178,6 +182,11 @@ jobs:
           context: .
           platforms: ${{ matrix.platform }}
           outputs: type=image,name=${{ env.GHCR_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+          build-args: |
+            VERSION=${{ needs.release.outputs.tag }}
+            REVISION=${{ github.sha }}
+            CREATED=${{ steps.meta.outputs.created }}
+            REPO_URL=https://github.com/${{ github.repository }}
 
       - name: Export digest
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,21 @@ RUN CGO_ENABLED=0 go build -ldflags="-s -w" -o /seerr-cli .
 # Stage 2: Final image
 FROM alpine:3.21
 
+# Build args for OCI standard image labels.
+ARG VERSION=dev
+ARG REVISION=unknown
+ARG CREATED=unknown
+ARG REPO_URL=https://github.com/electather/seerr-cli
+
+LABEL org.opencontainers.image.title="seerr-cli" \
+      org.opencontainers.image.description="Command-line interface and MCP server for the Seerr media request management API" \
+      org.opencontainers.image.url="${REPO_URL}" \
+      org.opencontainers.image.source="${REPO_URL}" \
+      org.opencontainers.image.version="${VERSION}" \
+      org.opencontainers.image.revision="${REVISION}" \
+      org.opencontainers.image.created="${CREATED}" \
+      org.opencontainers.image.licenses="MIT"
+
 RUN apk add --no-cache ca-certificates
 
 COPY --from=builder /seerr-cli /usr/local/bin/seerr-cli


### PR DESCRIPTION
## Summary

Adds [OCI standard image labels](https://github.com/opencontainers/image-spec/blob/main/annotations.md) to the published Docker images so tools like `docker inspect`, GitHub Container Registry, and image scanners can surface useful metadata.

## Changes

- Added `ARG` declarations and `LABEL` instructions to the final stage of `Dockerfile` for `org.opencontainers.image.{title,description,url,source,version,revision,created,licenses}`
- Added a "Generate image metadata" step to the `docker-build` job in `version.yml` that captures the build timestamp
- Passed `VERSION`, `REVISION`, `CREATED`, and `REPO_URL` as `build-args` to `docker/build-push-action`

## Test plan

- [ ] `go test -v ./...` passes
- [ ] `go fmt ./...` produces no diff
- [ ] `go build` succeeds
- [ ] After release, `docker buildx imagetools inspect ghcr.io/electather/seerr-cli:<version>` shows the OCI labels populated

## Checklist

- [x] New tests added for new behaviour — n/a (CI/Docker change)
- [x] Documentation updated (README, command `--help`, comments)
- [x] No unrelated changes included