### PR TITLE
fix(config): show only last 4 characters of API key in config show

### DIFF
--- a/cmd/config/show.go
+++ b/cmd/config/show.go
@@ -15,9 +15,11 @@ var configShowCmd = &cobra.Command{
 
 		apiKey := viper.GetString("seerr.api_key")
 		if apiKey != "" {
-			masked := apiKey
+			// Show only the last 4 characters so the key is identifiable without
+			// exposing the prefix, which is the more sensitive portion.
+			var masked string
 			if len(apiKey) > 4 {
-				masked = apiKey[:4] + "****" + apiKey[len(apiKey)-4:]
+				masked = "********" + apiKey[len(apiKey)-4:]
 			} else {
 				masked = "****"
 			}

--- a/tests/config_show_mask_test.go
+++ b/tests/config_show_mask_test.go
@@ -1,0 +1,97 @@
+package tests
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"seerr-cli/cmd"
+
+	"github.com/spf13/viper"
+)
+
+// writeConfigFile writes minimal YAML to a temp file so config show can read it.
+func writeConfigFile(t *testing.T, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	p := filepath.Join(dir, ".seerr-cli.yaml")
+	if err := os.WriteFile(p, []byte(content), 0o600); err != nil {
+		t.Fatalf("writeConfigFile: %v", err)
+	}
+	return p
+}
+
+func runConfigShow(t *testing.T, configPath string) string {
+	t.Helper()
+	viper.Reset()
+	b := new(bytes.Buffer)
+	cmd.RootCmd.SetOut(b)
+	cmd.RootCmd.SetErr(b)
+	cmd.RootCmd.SetArgs([]string{"config", "show", "--config", configPath})
+	if err := cmd.RootCmd.Execute(); err != nil {
+		t.Fatalf("config show: %v", err)
+	}
+	return b.String()
+}
+
+func TestConfigShowAPIKeyMasking(t *testing.T) {
+	tests := []struct {
+		name        string
+		apiKey      string
+		wantContain string
+		wantAbsent  string
+	}{
+		{
+			name:        "long key shows only last 4 chars",
+			apiKey:      "abcdefghijklmnop",
+			wantContain: "********mnop",
+			wantAbsent:  "abcd",
+		},
+		{
+			name:        "exactly 5 char key shows only last 4",
+			apiKey:      "hello",
+			wantContain: "****",
+			// "hell" must not appear
+			wantAbsent: "hell",
+		},
+		{
+			name:        "4 char key is fully masked",
+			apiKey:      "1234",
+			wantContain: "****",
+			wantAbsent:  "1234",
+		},
+		{
+			name:        "short key (2 chars) is fully masked",
+			apiKey:      "ab",
+			wantContain: "****",
+			wantAbsent:  "ab",
+		},
+		{
+			name:        "key absent shows not-set label",
+			apiKey:      "",
+			wantContain: "<not set>",
+			wantAbsent:  "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var yaml string
+			if tc.apiKey != "" {
+				yaml = "seerr:\n  server: http://localhost:5055\n  api_key: " + tc.apiKey + "\n"
+			} else {
+				yaml = "seerr:\n  server: http://localhost:5055\n"
+			}
+			p := writeConfigFile(t, yaml)
+			out := runConfigShow(t, p)
+			if !strings.Contains(out, tc.wantContain) {
+				t.Errorf("expected output to contain %q, got: %s", tc.wantContain, out)
+			}
+			if tc.wantAbsent != "" && strings.Contains(out, tc.wantAbsent) {
+				t.Errorf("expected output NOT to contain %q, got: %s", tc.wantAbsent, out)
+			}
+		})
+	}
+}

--- a/tests/config_test.go
+++ b/tests/config_test.go
@@ -91,9 +91,15 @@ func TestConfigCommands(t *testing.T) {
 		if !strings.Contains(out, "http://test-server:5055") {
 			t.Errorf("expected output to contain server URL, got: %s", out)
 		}
-		// Check for masked API key
-		if !strings.Contains(out, "test****2345") {
+		// Only the last 4 characters should be visible; the prefix is masked.
+		if !strings.Contains(out, "********2345") {
 			t.Errorf("expected output to contain masked API key, got: %s", out)
+		}
+		// The API Key line must not contain the plain-text prefix of the key.
+		for _, line := range strings.Split(out, "\n") {
+			if strings.HasPrefix(line, "API Key:") && strings.Contains(line, "test-api") {
+				t.Errorf("expected API key prefix to be masked in line: %s", line)
+			}
 		}
 	})
 


### PR DESCRIPTION
## Summary

Replace the `first4****last4` masking format with `********last4` so the API key prefix is never shown in plain text. This prevents accidental exposure when screenshots or logs of `config show` output are shared.

Closes #67

## Changes

- `cmd/config/show.go`: new masking logic — keys longer than 4 chars get `"********" + last4`; keys of 4 chars or fewer get `"****"`; absent keys still show `<not set>`
- `tests/config_test.go`: update existing assertion to expect the new `********2345` format and verify the prefix is not visible on the `API Key:` line
- `tests/config_show_mask_test.go`: new table-driven tests covering long keys, exactly-5-char keys, 4-char keys, 2-char keys, and absent keys

## Test plan

- [ ] `go test -v ./...` passes
- [ ] `go fmt ./...` produces no diff
- [ ] `go build` succeeds

## Checklist

- [x] New tests added for new behaviour
- [ ] Documentation updated (README, command `--help`, comments)
- [x] No unrelated changes included