### PR TITLE
refactor: replace float32/number identifiers with integer types

### DIFF
--- a/cmd/blocklist/add.go
+++ b/cmd/blocklist/add.go
@@ -16,8 +16,8 @@ var addCmd = &cobra.Command{
 
 		body := api.NewBlocklist()
 		if cmd.Flags().Changed("tmdb-id") {
-			v, _ := cmd.Flags().GetFloat32("tmdb-id")
-			body.SetTmdbId(v)
+			v, _ := cmd.Flags().GetInt("tmdb-id")
+			body.SetTmdbId(float32(v))
 		}
 
 		r, err := apiClient.BlocklistAPI.BlocklistPost(ctx).Blocklist(*body).Execute()
@@ -26,7 +26,7 @@ var addCmd = &cobra.Command{
 }
 
 func init() {
-	addCmd.Flags().Float32("tmdb-id", 0, "TMDB ID of the media to blocklist (required)")
+	addCmd.Flags().Int("tmdb-id", 0, "TMDB ID of the media to blocklist (required)")
 	addCmd.MarkFlagRequired("tmdb-id")
 	Cmd.AddCommand(addCmd)
 }

--- a/cmd/blocklist/list.go
+++ b/cmd/blocklist/list.go
@@ -20,12 +20,12 @@ var listCmd = &cobra.Command{
 		req := apiClient.BlocklistAPI.BlocklistGet(ctx)
 
 		if cmd.Flags().Changed("take") {
-			v, _ := cmd.Flags().GetFloat32("take")
-			req = req.Take(v)
+			v, _ := cmd.Flags().GetInt("take")
+			req = req.Take(float32(v))
 		}
 		if cmd.Flags().Changed("skip") {
-			v, _ := cmd.Flags().GetFloat32("skip")
-			req = req.Skip(v)
+			v, _ := cmd.Flags().GetInt("skip")
+			req = req.Skip(float32(v))
 		}
 		if cmd.Flags().Changed("search") {
 			v, _ := cmd.Flags().GetString("search")
@@ -42,8 +42,8 @@ var listCmd = &cobra.Command{
 }
 
 func init() {
-	listCmd.Flags().Float32("take", 20, "Number of items to return")
-	listCmd.Flags().Float32("skip", 0, "Number of items to skip")
+	listCmd.Flags().Int("take", 20, "Number of items to return")
+	listCmd.Flags().Int("skip", 0, "Number of items to skip")
 	listCmd.Flags().String("search", "", "Search by title")
 	listCmd.Flags().String("filter", "", "Filter: all, manual, blocklistedTags")
 	Cmd.AddCommand(listCmd)

--- a/cmd/collection/get.go
+++ b/cmd/collection/get.go
@@ -17,7 +17,7 @@ var getCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		apiClient, ctx, isVerbose := apiutil.NewAPIClient()
 
-		id, err := strconv.ParseFloat(args[0], 32)
+		id, err := strconv.ParseInt(args[0], 10, 64)
 		if err != nil {
 			return err
 		}

--- a/cmd/issue/comment.go
+++ b/cmd/issue/comment.go
@@ -15,7 +15,7 @@ var commentCmd = &cobra.Command{
 	Short: "Add a comment to an issue",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		id, err := strconv.ParseFloat(args[0], 32)
+		id, err := strconv.ParseInt(args[0], 10, 64)
 		if err != nil {
 			return fmt.Errorf("invalid issue ID: %s", args[0])
 		}

--- a/cmd/issue/create.go
+++ b/cmd/issue/create.go
@@ -15,7 +15,7 @@ var createCmd = &cobra.Command{
 	Short: "Create a new issue",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		issueType, err := strconv.ParseFloat(args[0], 32)
+		issueType, err := strconv.ParseInt(args[0], 10, 64)
 		if err != nil {
 			return fmt.Errorf("invalid issue type: %s", args[0])
 		}
@@ -26,8 +26,8 @@ var createCmd = &cobra.Command{
 			body.SetMessage(v)
 		}
 		if cmd.Flags().Changed("media-id") {
-			v, _ := cmd.Flags().GetFloat32("media-id")
-			body.SetMediaId(v)
+			v, _ := cmd.Flags().GetInt("media-id")
+			body.SetMediaId(float32(v))
 		}
 		apiClient, ctx, isVerbose := apiutil.NewAPIClient()
 		res, r, apiErr := apiClient.IssueAPI.IssuePost(ctx).IssuePostRequest(*body).Execute()
@@ -37,6 +37,6 @@ var createCmd = &cobra.Command{
 
 func init() {
 	createCmd.Flags().String("message", "", "Issue message")
-	createCmd.Flags().Float32("media-id", 0, "Media ID associated with the issue")
+	createCmd.Flags().Int("media-id", 0, "Media ID associated with the issue")
 	Cmd.AddCommand(createCmd)
 }

--- a/cmd/issue/get.go
+++ b/cmd/issue/get.go
@@ -13,7 +13,7 @@ var getCmd = &cobra.Command{
 	Short: "Get a single issue",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		id, err := strconv.ParseFloat(args[0], 32)
+		id, err := strconv.ParseInt(args[0], 10, 64)
 		if err != nil {
 			return fmt.Errorf("invalid issue ID: %s", args[0])
 		}

--- a/cmd/issue/list.go
+++ b/cmd/issue/list.go
@@ -13,12 +13,12 @@ var listCmd = &cobra.Command{
 		apiClient, ctx, isVerbose := apiutil.NewAPIClient()
 		req := apiClient.IssueAPI.IssueGet(ctx)
 		if cmd.Flags().Changed("take") {
-			v, _ := cmd.Flags().GetFloat32("take")
-			req = req.Take(v)
+			v, _ := cmd.Flags().GetInt("take")
+			req = req.Take(float32(v))
 		}
 		if cmd.Flags().Changed("skip") {
-			v, _ := cmd.Flags().GetFloat32("skip")
-			req = req.Skip(v)
+			v, _ := cmd.Flags().GetInt("skip")
+			req = req.Skip(float32(v))
 		}
 		if cmd.Flags().Changed("sort") {
 			v, _ := cmd.Flags().GetString("sort")
@@ -29,8 +29,8 @@ var listCmd = &cobra.Command{
 			req = req.Filter(v)
 		}
 		if cmd.Flags().Changed("requested-by") {
-			v, _ := cmd.Flags().GetFloat32("requested-by")
-			req = req.RequestedBy(v)
+			v, _ := cmd.Flags().GetInt("requested-by")
+			req = req.RequestedBy(float32(v))
 		}
 		res, r, err := req.Execute()
 		return apiutil.HandleResponse(cmd, r, err, res, isVerbose, "IssueGet")
@@ -38,10 +38,10 @@ var listCmd = &cobra.Command{
 }
 
 func init() {
-	listCmd.Flags().Float32("take", 20, "Number of issues to return")
-	listCmd.Flags().Float32("skip", 0, "Number of issues to skip")
+	listCmd.Flags().Int("take", 20, "Number of issues to return")
+	listCmd.Flags().Int("skip", 0, "Number of issues to skip")
 	listCmd.Flags().String("sort", "added", "Sort by: added, modified")
 	listCmd.Flags().String("filter", "open", "Filter by status: all, open, resolved")
-	listCmd.Flags().Float32("requested-by", 0, "Filter by user ID")
+	listCmd.Flags().Int("requested-by", 0, "Filter by user ID")
 	Cmd.AddCommand(listCmd)
 }

--- a/cmd/mcp/enrich.go
+++ b/cmd/mcp/enrich.go
@@ -13,7 +13,7 @@ import (
 const tmdbImageBase = "https://image.tmdb.org/t/p/w500"
 
 // GenreMap maps a TMDB genre ID to its human-readable name.
-type GenreMap map[float32]string
+type GenreMap map[int]string
 
 // FetchMovieGenres fetches the TMDB movie genre list and returns a lookup map.
 // Returns nil on error; genre enrichment is best-effort.
@@ -25,7 +25,7 @@ func FetchMovieGenres(ctx context.Context, client *api.APIClient) GenreMap {
 	m := make(GenreMap, len(genres))
 	for _, g := range genres {
 		if g.Id != nil && g.Name != nil {
-			m[*g.Id] = *g.Name
+			m[int(*g.Id)] = *g.Name
 		}
 	}
 	return m
@@ -41,7 +41,7 @@ func FetchTVGenres(ctx context.Context, client *api.APIClient) GenreMap {
 	m := make(GenreMap, len(genres))
 	for _, g := range genres {
 		if g.Id != nil && g.Name != nil {
-			m[*g.Id] = *g.Name
+			m[int(*g.Id)] = *g.Name
 		}
 	}
 	return m
@@ -87,7 +87,7 @@ func EnrichMediaMap(m map[string]interface{}, genres GenreMap) {
 			names := make([]string, 0, len(ids))
 			for _, v := range ids {
 				if id, ok := v.(float64); ok {
-					if name := genres[float32(id)]; name != "" {
+					if name := genres[int(id)]; name != "" {
 						names = append(names, name)
 					}
 				}

--- a/cmd/mcp/tools_blocklist.go
+++ b/cmd/mcp/tools_blocklist.go
@@ -51,10 +51,10 @@ func BlocklistListHandler() server.ToolHandlerFunc {
 	return func(callCtx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		client := newAPIClientWithKey(apiKeyFromContext(callCtx))
 		r := client.BlocklistAPI.BlocklistGet(callCtx)
-		if take := req.GetFloat("take", 0); take > 0 {
+		if take := req.GetInt("take", 0); take > 0 {
 			r = r.Take(float32(take))
 		}
-		if skip := req.GetFloat("skip", 0); skip > 0 {
+		if skip := req.GetInt("skip", 0); skip > 0 {
 			r = r.Skip(float32(skip))
 		}
 		res, _, err := r.Execute()
@@ -71,13 +71,13 @@ func BlocklistListHandler() server.ToolHandlerFunc {
 
 func BlocklistAddHandler() server.ToolHandlerFunc {
 	return func(callCtx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		tmdbId, err := req.RequireFloat("tmdbId")
+		tmdbId, err := req.RequireInt("tmdbId")
 		if err != nil {
 			return nil, err
 		}
-		tmdbIdFloat := float32(tmdbId)
+		tmdbIdF := float32(tmdbId)
 		body := api.Blocklist{
-			TmdbId: &tmdbIdFloat,
+			TmdbId: &tmdbIdF,
 		}
 		if title := req.GetString("title", ""); title != "" {
 			body.Title = &title

--- a/cmd/mcp/tools_collection.go
+++ b/cmd/mcp/tools_collection.go
@@ -23,7 +23,7 @@ func registerCollectionTools(s *server.MCPServer) {
 
 func CollectionGetHandler() server.ToolHandlerFunc {
 	return func(callCtx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		collectionId, err := req.RequireFloat("collectionId")
+		collectionId, err := req.RequireInt("collectionId")
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/mcp/tools_issues.go
+++ b/cmd/mcp/tools_issues.go
@@ -74,10 +74,10 @@ func IssueListHandler() server.ToolHandlerFunc {
 	return func(callCtx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		client := newAPIClientWithKey(apiKeyFromContext(callCtx))
 		r := client.IssueAPI.IssueGet(callCtx)
-		if take := req.GetFloat("take", 0); take > 0 {
+		if take := req.GetInt("take", 0); take > 0 {
 			r = r.Take(float32(take))
 		}
-		if skip := req.GetFloat("skip", 0); skip > 0 {
+		if skip := req.GetInt("skip", 0); skip > 0 {
 			r = r.Skip(float32(skip))
 		}
 		res, _, err := r.Execute()
@@ -94,7 +94,7 @@ func IssueListHandler() server.ToolHandlerFunc {
 
 func IssueGetHandler() server.ToolHandlerFunc {
 	return func(callCtx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		issueId, err := req.RequireFloat("issueId")
+		issueId, err := req.RequireInt("issueId")
 		if err != nil {
 			return nil, err
 		}
@@ -113,7 +113,7 @@ func IssueGetHandler() server.ToolHandlerFunc {
 
 func IssueCreateHandler() server.ToolHandlerFunc {
 	return func(callCtx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		issueType, err := req.RequireFloat("issueType")
+		issueType, err := req.RequireInt("issueType")
 		if err != nil {
 			return nil, err
 		}
@@ -121,16 +121,16 @@ func IssueCreateHandler() server.ToolHandlerFunc {
 		if err != nil {
 			return nil, err
 		}
-		mediaId, err := req.RequireFloat("mediaId")
+		mediaId, err := req.RequireInt("mediaId")
 		if err != nil {
 			return nil, err
 		}
-		issueTypeFloat := float32(issueType)
-		mediaIdFloat := float32(mediaId)
+		issueTypeF := float32(issueType)
+		mediaIdF := float32(mediaId)
 		body := api.IssuePostRequest{
-			IssueType: &issueTypeFloat,
+			IssueType: &issueTypeF,
 			Message:   &message,
-			MediaId:   &mediaIdFloat,
+			MediaId:   &mediaIdF,
 		}
 		client := newAPIClientWithKey(apiKeyFromContext(callCtx))
 		res, _, err := client.IssueAPI.IssuePost(callCtx).IssuePostRequest(body).Execute()

--- a/cmd/mcp/tools_media.go
+++ b/cmd/mcp/tools_media.go
@@ -58,9 +58,9 @@ func MediaListHandler() server.ToolHandlerFunc {
 	return func(callCtx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		client := newAPIClientWithKey(apiKeyFromContext(callCtx))
 		r := client.MediaAPI.MediaGet(callCtx)
-		take := req.GetFloat("take", 20)
+		take := req.GetInt("take", 20)
 		r = r.Take(float32(take))
-		if skip := req.GetFloat("skip", 0); skip > 0 {
+		if skip := req.GetInt("skip", 0); skip > 0 {
 			r = r.Skip(float32(skip))
 		}
 		if filter := req.GetString("filter", ""); filter != "" {

--- a/cmd/mcp/tools_movies.go
+++ b/cmd/mcp/tools_movies.go
@@ -58,7 +58,7 @@ func registerMoviesTools(s *server.MCPServer) {
 
 func MoviesGetHandler() server.ToolHandlerFunc {
 	return func(callCtx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		movieId, err := req.RequireFloat("movieId")
+		movieId, err := req.RequireInt("movieId")
 		if err != nil {
 			return nil, err
 		}
@@ -77,13 +77,13 @@ func MoviesGetHandler() server.ToolHandlerFunc {
 
 func MoviesRecommendationsHandler() server.ToolHandlerFunc {
 	return func(callCtx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		movieId, err := req.RequireFloat("movieId")
+		movieId, err := req.RequireInt("movieId")
 		if err != nil {
 			return nil, err
 		}
 		client := newAPIClientWithKey(apiKeyFromContext(callCtx))
 		r := client.MoviesAPI.MovieMovieIdRecommendationsGet(callCtx, float32(movieId))
-		if page := req.GetFloat("page", 0); page > 0 {
+		if page := req.GetInt("page", 0); page > 0 {
 			r = r.Page(float32(page))
 		}
 		res, _, err := r.Execute()
@@ -100,13 +100,13 @@ func MoviesRecommendationsHandler() server.ToolHandlerFunc {
 
 func MoviesSimilarHandler() server.ToolHandlerFunc {
 	return func(callCtx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		movieId, err := req.RequireFloat("movieId")
+		movieId, err := req.RequireInt("movieId")
 		if err != nil {
 			return nil, err
 		}
 		client := newAPIClientWithKey(apiKeyFromContext(callCtx))
 		r := client.MoviesAPI.MovieMovieIdSimilarGet(callCtx, float32(movieId))
-		if page := req.GetFloat("page", 0); page > 0 {
+		if page := req.GetInt("page", 0); page > 0 {
 			r = r.Page(float32(page))
 		}
 		res, _, err := r.Execute()
@@ -123,7 +123,7 @@ func MoviesSimilarHandler() server.ToolHandlerFunc {
 
 func MoviesRatingsHandler() server.ToolHandlerFunc {
 	return func(callCtx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		movieId, err := req.RequireFloat("movieId")
+		movieId, err := req.RequireInt("movieId")
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/mcp/tools_person.go
+++ b/cmd/mcp/tools_person.go
@@ -34,7 +34,7 @@ func registerPersonTools(s *server.MCPServer) {
 
 func PersonGetHandler() server.ToolHandlerFunc {
 	return func(callCtx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		personId, err := req.RequireFloat("personId")
+		personId, err := req.RequireInt("personId")
 		if err != nil {
 			return nil, err
 		}
@@ -53,7 +53,7 @@ func PersonGetHandler() server.ToolHandlerFunc {
 
 func PersonCreditsHandler() server.ToolHandlerFunc {
 	return func(callCtx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		personId, err := req.RequireFloat("personId")
+		personId, err := req.RequireInt("personId")
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/mcp/tools_request.go
+++ b/cmd/mcp/tools_request.go
@@ -105,10 +105,10 @@ func RequestListHandler() server.ToolHandlerFunc {
 	return func(callCtx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		client := newAPIClientWithKey(apiKeyFromContext(callCtx))
 		r := client.RequestAPI.RequestGet(callCtx)
-		if take := req.GetFloat("take", 0); take > 0 {
+		if take := req.GetInt("take", 0); take > 0 {
 			r = r.Take(float32(take))
 		}
-		if skip := req.GetFloat("skip", 0); skip > 0 {
+		if skip := req.GetInt("skip", 0); skip > 0 {
 			r = r.Skip(float32(skip))
 		}
 		if filter := req.GetString("filter", ""); filter != "" {
@@ -154,7 +154,7 @@ func RequestCreateHandler() server.ToolHandlerFunc {
 		if err != nil {
 			return nil, err
 		}
-		mediaId, err := req.RequireFloat("mediaId")
+		mediaId, err := req.RequireInt("mediaId")
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/mcp/tools_tv.go
+++ b/cmd/mcp/tools_tv.go
@@ -70,7 +70,7 @@ func registerTVTools(s *server.MCPServer) {
 
 func TVGetHandler() server.ToolHandlerFunc {
 	return func(callCtx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		tvId, err := req.RequireFloat("tvId")
+		tvId, err := req.RequireInt("tvId")
 		if err != nil {
 			return nil, err
 		}
@@ -89,11 +89,11 @@ func TVGetHandler() server.ToolHandlerFunc {
 
 func TVSeasonHandler() server.ToolHandlerFunc {
 	return func(callCtx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		tvId, err := req.RequireFloat("tvId")
+		tvId, err := req.RequireInt("tvId")
 		if err != nil {
 			return nil, err
 		}
-		seasonNumber, err := req.RequireFloat("seasonNumber")
+		seasonNumber, err := req.RequireInt("seasonNumber")
 		if err != nil {
 			return nil, err
 		}
@@ -112,13 +112,13 @@ func TVSeasonHandler() server.ToolHandlerFunc {
 
 func TVRecommendationsHandler() server.ToolHandlerFunc {
 	return func(callCtx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		tvId, err := req.RequireFloat("tvId")
+		tvId, err := req.RequireInt("tvId")
 		if err != nil {
 			return nil, err
 		}
 		client := newAPIClientWithKey(apiKeyFromContext(callCtx))
 		r := client.TvAPI.TvTvIdRecommendationsGet(callCtx, float32(tvId))
-		if page := req.GetFloat("page", 0); page > 0 {
+		if page := req.GetInt("page", 0); page > 0 {
 			r = r.Page(float32(page))
 		}
 		res, _, err := r.Execute()
@@ -135,13 +135,13 @@ func TVRecommendationsHandler() server.ToolHandlerFunc {
 
 func TVSimilarHandler() server.ToolHandlerFunc {
 	return func(callCtx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		tvId, err := req.RequireFloat("tvId")
+		tvId, err := req.RequireInt("tvId")
 		if err != nil {
 			return nil, err
 		}
 		client := newAPIClientWithKey(apiKeyFromContext(callCtx))
 		r := client.TvAPI.TvTvIdSimilarGet(callCtx, float32(tvId))
-		if page := req.GetFloat("page", 0); page > 0 {
+		if page := req.GetInt("page", 0); page > 0 {
 			r = r.Page(float32(page))
 		}
 		res, _, err := r.Execute()
@@ -158,7 +158,7 @@ func TVSimilarHandler() server.ToolHandlerFunc {
 
 func TVRatingsHandler() server.ToolHandlerFunc {
 	return func(callCtx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		tvId, err := req.RequireFloat("tvId")
+		tvId, err := req.RequireInt("tvId")
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/mcp/tools_users.go
+++ b/cmd/mcp/tools_users.go
@@ -52,10 +52,10 @@ func UsersListHandler() server.ToolHandlerFunc {
 	return func(callCtx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		client := newAPIClientWithKey(apiKeyFromContext(callCtx))
 		r := client.UsersAPI.UserGet(callCtx)
-		if take := req.GetFloat("take", 0); take > 0 {
+		if take := req.GetInt("take", 0); take > 0 {
 			r = r.Take(float32(take))
 		}
-		if skip := req.GetFloat("skip", 0); skip > 0 {
+		if skip := req.GetInt("skip", 0); skip > 0 {
 			r = r.Skip(float32(skip))
 		}
 		res, _, err := r.Execute()
@@ -72,7 +72,7 @@ func UsersListHandler() server.ToolHandlerFunc {
 
 func UsersGetHandler() server.ToolHandlerFunc {
 	return func(callCtx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		userId, err := req.RequireFloat("userId")
+		userId, err := req.RequireInt("userId")
 		if err != nil {
 			return nil, err
 		}
@@ -91,7 +91,7 @@ func UsersGetHandler() server.ToolHandlerFunc {
 
 func UsersUpdateHandler() server.ToolHandlerFunc {
 	return func(callCtx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		userId, err := req.RequireFloat("userId")
+		userId, err := req.RequireInt("userId")
 		if err != nil {
 			return nil, err
 		}
@@ -105,9 +105,8 @@ func UsersUpdateHandler() server.ToolHandlerFunc {
 			body.SetUsername(v)
 			changed = true
 		}
-		if v := req.GetFloat("permissions", -1); v >= 0 {
-			f := float32(v)
-			body.SetPermissions(f)
+		if v := req.GetInt("permissions", -1); v >= 0 {
+			body.SetPermissions(float32(v))
 			changed = true
 		}
 		if !changed {
@@ -128,7 +127,7 @@ func UsersUpdateHandler() server.ToolHandlerFunc {
 
 func UsersQuotaHandler() server.ToolHandlerFunc {
 	return func(callCtx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		userId, err := req.RequireFloat("userId")
+		userId, err := req.RequireInt("userId")
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/mcp/tools_watchlist.go
+++ b/cmd/mcp/tools_watchlist.go
@@ -32,7 +32,7 @@ func registerWatchlistTools(s *server.MCPServer) {
 
 func WatchlistAddHandler() server.ToolHandlerFunc {
 	return func(callCtx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		tmdbId, err := req.RequireFloat("tmdbId")
+		tmdbId, err := req.RequireInt("tmdbId")
 		if err != nil {
 			return nil, err
 		}
@@ -44,9 +44,9 @@ func WatchlistAddHandler() server.ToolHandlerFunc {
 		if err != nil {
 			return nil, err
 		}
-		tmdbIdFloat := float32(tmdbId)
+		tmdbIdF := float32(tmdbId)
 		body := api.Watchlist{
-			TmdbId: &tmdbIdFloat,
+			TmdbId: &tmdbIdF,
 			Title:  &title,
 			Type:   &mediaType,
 		}

--- a/cmd/media/list.go
+++ b/cmd/media/list.go
@@ -23,12 +23,12 @@ var listCmd = &cobra.Command{
 		req := apiClient.MediaAPI.MediaGet(ctx)
 
 		if cmd.Flags().Changed("take") {
-			v, _ := cmd.Flags().GetFloat32("take")
-			req = req.Take(v)
+			v, _ := cmd.Flags().GetInt("take")
+			req = req.Take(float32(v))
 		}
 		if cmd.Flags().Changed("skip") {
-			v, _ := cmd.Flags().GetFloat32("skip")
-			req = req.Skip(v)
+			v, _ := cmd.Flags().GetInt("skip")
+			req = req.Skip(float32(v))
 		}
 		if cmd.Flags().Changed("filter") {
 			v, _ := cmd.Flags().GetString("filter")
@@ -45,8 +45,8 @@ var listCmd = &cobra.Command{
 }
 
 func init() {
-	listCmd.Flags().Float32("take", 20, "Number of items to return")
-	listCmd.Flags().Float32("skip", 0, "Number of items to skip")
+	listCmd.Flags().Int("take", 20, "Number of items to return")
+	listCmd.Flags().Int("skip", 0, "Number of items to skip")
 	listCmd.Flags().String("filter", "", "Filter by status: all, available, partial, allavailable, processing, pending, deleted")
 	listCmd.Flags().String("sort", "", "Sort by: added, modified, mediaAdded")
 	Cmd.AddCommand(listCmd)

--- a/cmd/movies/get.go
+++ b/cmd/movies/get.go
@@ -20,7 +20,7 @@ var getCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		apiClient, ctx, isVerbose := apiutil.NewAPIClient()
 
-		movieId, err := strconv.ParseFloat(args[0], 32)
+		movieId, err := strconv.ParseInt(args[0], 10, 64)
 		if err != nil {
 			return err
 		}

--- a/cmd/movies/ratings.go
+++ b/cmd/movies/ratings.go
@@ -17,7 +17,7 @@ var ratingsCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		apiClient, ctx, isVerbose := apiutil.NewAPIClient()
 
-		movieId, err := strconv.ParseFloat(args[0], 32)
+		movieId, err := strconv.ParseInt(args[0], 10, 64)
 		if err != nil {
 			return err
 		}

--- a/cmd/movies/ratings_combined.go
+++ b/cmd/movies/ratings_combined.go
@@ -17,7 +17,7 @@ var ratingsCombinedCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		apiClient, ctx, isVerbose := apiutil.NewAPIClient()
 
-		movieId, err := strconv.ParseFloat(args[0], 32)
+		movieId, err := strconv.ParseInt(args[0], 10, 64)
 		if err != nil {
 			return err
 		}

--- a/cmd/movies/recommendations.go
+++ b/cmd/movies/recommendations.go
@@ -20,17 +20,17 @@ var recommendationsCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		apiClient, ctx, isVerbose := apiutil.NewAPIClient()
 
-		movieId, err := strconv.ParseFloat(args[0], 32)
+		movieId, err := strconv.ParseInt(args[0], 10, 64)
 		if err != nil {
 			return err
 		}
 
-		page, _ := cmd.Flags().GetFloat32("page")
+		page, _ := cmd.Flags().GetInt("page")
 		language, _ := cmd.Flags().GetString("language")
 
 		req := apiClient.MoviesAPI.MovieMovieIdRecommendationsGet(ctx, float32(movieId))
 		if cmd.Flags().Changed("page") {
-			req = req.Page(page)
+			req = req.Page(float32(page))
 		}
 		if cmd.Flags().Changed("language") {
 			req = req.Language(language)
@@ -42,7 +42,7 @@ var recommendationsCmd = &cobra.Command{
 }
 
 func init() {
-	recommendationsCmd.Flags().Float32("page", 1, "Page number")
+	recommendationsCmd.Flags().Int("page", 1, "Page number")
 	recommendationsCmd.Flags().String("language", "en", "Language code")
 	Cmd.AddCommand(recommendationsCmd)
 }

--- a/cmd/movies/similar.go
+++ b/cmd/movies/similar.go
@@ -17,17 +17,17 @@ var similarCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		apiClient, ctx, isVerbose := apiutil.NewAPIClient()
 
-		movieId, err := strconv.ParseFloat(args[0], 32)
+		movieId, err := strconv.ParseInt(args[0], 10, 64)
 		if err != nil {
 			return err
 		}
 
-		page, _ := cmd.Flags().GetFloat32("page")
+		page, _ := cmd.Flags().GetInt("page")
 		language, _ := cmd.Flags().GetString("language")
 
 		req := apiClient.MoviesAPI.MovieMovieIdSimilarGet(ctx, float32(movieId))
 		if cmd.Flags().Changed("page") {
-			req = req.Page(page)
+			req = req.Page(float32(page))
 		}
 		if cmd.Flags().Changed("language") {
 			req = req.Language(language)
@@ -39,7 +39,7 @@ var similarCmd = &cobra.Command{
 }
 
 func init() {
-	similarCmd.Flags().Float32("page", 1, "Page number")
+	similarCmd.Flags().Int("page", 1, "Page number")
 	similarCmd.Flags().String("language", "en", "Language code")
 	Cmd.AddCommand(similarCmd)
 }

--- a/cmd/other/keyword.go
+++ b/cmd/other/keyword.go
@@ -16,7 +16,7 @@ var keywordCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		apiClient, ctx, isVerbose := apiutil.NewAPIClient()
 
-		keywordId, err := strconv.ParseFloat(args[0], 32)
+		keywordId, err := strconv.ParseInt(args[0], 10, 64)
 		if err != nil {
 			return err
 		}

--- a/cmd/overriderule/delete.go
+++ b/cmd/overriderule/delete.go
@@ -14,7 +14,7 @@ var deleteCmd = &cobra.Command{
 	Short: "Delete an override rule",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		id, err := strconv.ParseFloat(args[0], 32)
+		id, err := strconv.ParseInt(args[0], 10, 64)
 		if err != nil {
 			return fmt.Errorf("invalid rule ID: %s", args[0])
 		}

--- a/cmd/overriderule/update.go
+++ b/cmd/overriderule/update.go
@@ -14,7 +14,7 @@ var updateCmd = &cobra.Command{
 	Short: "Update an override rule",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		id, err := strconv.ParseFloat(args[0], 32)
+		id, err := strconv.ParseInt(args[0], 10, 64)
 		if err != nil {
 			return fmt.Errorf("invalid rule ID: %s", args[0])
 		}

--- a/cmd/person/combined_credits.go
+++ b/cmd/person/combined_credits.go
@@ -20,7 +20,7 @@ var combinedCreditsCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		apiClient, ctx, isVerbose := apiutil.NewAPIClient()
 
-		personId, err := strconv.ParseFloat(args[0], 32)
+		personId, err := strconv.ParseInt(args[0], 10, 64)
 		if err != nil {
 			return err
 		}

--- a/cmd/person/get.go
+++ b/cmd/person/get.go
@@ -20,7 +20,7 @@ var getCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		apiClient, ctx, isVerbose := apiutil.NewAPIClient()
 
-		personId, err := strconv.ParseFloat(args[0], 32)
+		personId, err := strconv.ParseInt(args[0], 10, 64)
 		if err != nil {
 			return err
 		}

--- a/cmd/request/create.go
+++ b/cmd/request/create.go
@@ -18,12 +18,12 @@ var createCmd = &cobra.Command{
 		apiClient, ctx, isVerbose := apiutil.NewAPIClient()
 
 		mediaType, _ := cmd.Flags().GetString("media-type")
-		mediaId, _ := cmd.Flags().GetFloat32("media-id")
-		body := *api.NewRequestPostRequest(mediaType, mediaId)
+		mediaId, _ := cmd.Flags().GetInt("media-id")
+		body := *api.NewRequestPostRequest(mediaType, float32(mediaId))
 
 		if cmd.Flags().Changed("tvdb-id") {
-			v, _ := cmd.Flags().GetFloat32("tvdb-id")
-			body.SetTvdbId(v)
+			v, _ := cmd.Flags().GetInt("tvdb-id")
+			body.SetTvdbId(float32(v))
 		}
 		if cmd.Flags().Changed("seasons") {
 			v, _ := cmd.Flags().GetString("seasons")
@@ -33,7 +33,7 @@ var createCmd = &cobra.Command{
 				parts := strings.Split(v, ",")
 				nums := make([]float32, 0, len(parts))
 				for _, p := range parts {
-					n, err := strconv.ParseFloat(strings.TrimSpace(p), 32)
+					n, err := strconv.ParseInt(strings.TrimSpace(p), 10, 64)
 					if err != nil {
 						return fmt.Errorf("invalid season number %q: %w", p, err)
 					}
@@ -47,24 +47,24 @@ var createCmd = &cobra.Command{
 			body.SetIs4k(v)
 		}
 		if cmd.Flags().Changed("server-id") {
-			v, _ := cmd.Flags().GetFloat32("server-id")
-			body.SetServerId(v)
+			v, _ := cmd.Flags().GetInt("server-id")
+			body.SetServerId(float32(v))
 		}
 		if cmd.Flags().Changed("profile-id") {
-			v, _ := cmd.Flags().GetFloat32("profile-id")
-			body.SetProfileId(v)
+			v, _ := cmd.Flags().GetInt("profile-id")
+			body.SetProfileId(float32(v))
 		}
 		if cmd.Flags().Changed("root-folder") {
 			v, _ := cmd.Flags().GetString("root-folder")
 			body.SetRootFolder(v)
 		}
 		if cmd.Flags().Changed("language-profile-id") {
-			v, _ := cmd.Flags().GetFloat32("language-profile-id")
-			body.SetLanguageProfileId(v)
+			v, _ := cmd.Flags().GetInt("language-profile-id")
+			body.SetLanguageProfileId(float32(v))
 		}
 		if cmd.Flags().Changed("user-id") {
-			v, _ := cmd.Flags().GetFloat32("user-id")
-			body.SetUserId(v)
+			v, _ := cmd.Flags().GetInt("user-id")
+			body.SetUserId(float32(v))
 		}
 
 		res, r, err := apiClient.RequestAPI.RequestPost(ctx).RequestPostRequest(body).Execute()
@@ -75,15 +75,15 @@ var createCmd = &cobra.Command{
 func init() {
 	createCmd.Flags().String("media-type", "", "Media type: movie or tv (required)")
 	createCmd.MarkFlagRequired("media-type")
-	createCmd.Flags().Float32("media-id", 0, "The TMDB media ID (required)")
+	createCmd.Flags().Int("media-id", 0, "The TMDB media ID (required)")
 	createCmd.MarkFlagRequired("media-id")
-	createCmd.Flags().Float32("tvdb-id", 0, "TVDB ID")
+	createCmd.Flags().Int("tvdb-id", 0, "TVDB ID")
 	createCmd.Flags().String("seasons", "", `Seasons to request: "all" or comma-separated numbers (e.g. "1,2,3")`)
 	createCmd.Flags().Bool("is4k", false, "Request 4K version")
-	createCmd.Flags().Float32("server-id", 0, "Target server ID")
-	createCmd.Flags().Float32("profile-id", 0, "Quality profile ID")
+	createCmd.Flags().Int("server-id", 0, "Target server ID")
+	createCmd.Flags().Int("profile-id", 0, "Quality profile ID")
 	createCmd.Flags().String("root-folder", "", "Root folder path")
-	createCmd.Flags().Float32("language-profile-id", 0, "Language profile ID")
-	createCmd.Flags().Float32("user-id", 0, "User ID to create request as")
+	createCmd.Flags().Int("language-profile-id", 0, "Language profile ID")
+	createCmd.Flags().Int("user-id", 0, "User ID to create request as")
 	Cmd.AddCommand(createCmd)
 }

--- a/cmd/request/list.go
+++ b/cmd/request/list.go
@@ -14,12 +14,12 @@ var listCmd = &cobra.Command{
 		req := apiClient.RequestAPI.RequestGet(ctx)
 
 		if cmd.Flags().Changed("take") {
-			v, _ := cmd.Flags().GetFloat32("take")
-			req = req.Take(v)
+			v, _ := cmd.Flags().GetInt("take")
+			req = req.Take(float32(v))
 		}
 		if cmd.Flags().Changed("skip") {
-			v, _ := cmd.Flags().GetFloat32("skip")
-			req = req.Skip(v)
+			v, _ := cmd.Flags().GetInt("skip")
+			req = req.Skip(float32(v))
 		}
 		if cmd.Flags().Changed("filter") {
 			v, _ := cmd.Flags().GetString("filter")
@@ -34,8 +34,8 @@ var listCmd = &cobra.Command{
 			req = req.SortDirection(v)
 		}
 		if cmd.Flags().Changed("requested-by") {
-			v, _ := cmd.Flags().GetFloat32("requested-by")
-			req = req.RequestedBy(v)
+			v, _ := cmd.Flags().GetInt("requested-by")
+			req = req.RequestedBy(float32(v))
 		}
 		if cmd.Flags().Changed("media-type") {
 			v, _ := cmd.Flags().GetString("media-type")
@@ -48,12 +48,12 @@ var listCmd = &cobra.Command{
 }
 
 func init() {
-	listCmd.Flags().Float32("take", 0, "Number of results to return")
-	listCmd.Flags().Float32("skip", 0, "Number of results to skip")
+	listCmd.Flags().Int("take", 0, "Number of results to return")
+	listCmd.Flags().Int("skip", 0, "Number of results to skip")
 	listCmd.Flags().String("filter", "", "Filter by status (all, approved, available, pending, processing, unavailable, failed, deleted, completed)")
 	listCmd.Flags().String("sort", "added", "Sort field (added, modified)")
 	listCmd.Flags().String("sort-direction", "desc", "Sort direction (asc, desc)")
-	listCmd.Flags().Float32("requested-by", 0, "Filter by requesting user ID")
+	listCmd.Flags().Int("requested-by", 0, "Filter by requesting user ID")
 	listCmd.Flags().String("media-type", "all", "Filter by media type (movie, tv, all)")
 	Cmd.AddCommand(listCmd)
 }

--- a/cmd/request/update.go
+++ b/cmd/request/update.go
@@ -27,7 +27,7 @@ var updateCmd = &cobra.Command{
 			parts := strings.Split(v, ",")
 			nums := make([]float32, 0, len(parts))
 			for _, p := range parts {
-				n, err := strconv.ParseFloat(strings.TrimSpace(p), 32)
+				n, err := strconv.ParseInt(strings.TrimSpace(p), 10, 64)
 				if err != nil {
 					return fmt.Errorf("invalid season number %q: %w", p, err)
 				}
@@ -42,13 +42,13 @@ var updateCmd = &cobra.Command{
 			changed = true
 		}
 		if cmd.Flags().Changed("server-id") {
-			v, _ := cmd.Flags().GetFloat32("server-id")
-			body.SetServerId(v)
+			v, _ := cmd.Flags().GetInt("server-id")
+			body.SetServerId(float32(v))
 			changed = true
 		}
 		if cmd.Flags().Changed("profile-id") {
-			v, _ := cmd.Flags().GetFloat32("profile-id")
-			body.SetProfileId(v)
+			v, _ := cmd.Flags().GetInt("profile-id")
+			body.SetProfileId(float32(v))
 			changed = true
 		}
 		if cmd.Flags().Changed("root-folder") {
@@ -57,13 +57,13 @@ var updateCmd = &cobra.Command{
 			changed = true
 		}
 		if cmd.Flags().Changed("language-profile-id") {
-			v, _ := cmd.Flags().GetFloat32("language-profile-id")
-			body.SetLanguageProfileId(v)
+			v, _ := cmd.Flags().GetInt("language-profile-id")
+			body.SetLanguageProfileId(float32(v))
 			changed = true
 		}
 		if cmd.Flags().Changed("user-id") {
-			v, _ := cmd.Flags().GetFloat32("user-id")
-			body.SetUserId(v)
+			v, _ := cmd.Flags().GetInt("user-id")
+			body.SetUserId(float32(v))
 			changed = true
 		}
 		if !changed {
@@ -80,10 +80,10 @@ func init() {
 	updateCmd.MarkFlagRequired("media-type")
 	updateCmd.Flags().String("seasons", "", `Comma-separated season numbers (e.g. "1,2,3")`)
 	updateCmd.Flags().Bool("is4k", false, "Request 4K version")
-	updateCmd.Flags().Float32("server-id", 0, "Target server ID")
-	updateCmd.Flags().Float32("profile-id", 0, "Quality profile ID")
+	updateCmd.Flags().Int("server-id", 0, "Target server ID")
+	updateCmd.Flags().Int("profile-id", 0, "Quality profile ID")
 	updateCmd.Flags().String("root-folder", "", "Root folder path")
-	updateCmd.Flags().Float32("language-profile-id", 0, "Language profile ID")
-	updateCmd.Flags().Float32("user-id", 0, "User ID")
+	updateCmd.Flags().Int("language-profile-id", 0, "Language profile ID")
+	updateCmd.Flags().Int("user-id", 0, "User ID")
 	Cmd.AddCommand(updateCmd)
 }

--- a/cmd/search/company.go
+++ b/cmd/search/company.go
@@ -15,11 +15,11 @@ var companyCmd = &cobra.Command{
 		apiClient, ctx, isVerbose := newAPIClient()
 
 		query, _ := cmd.Flags().GetString("query")
-		page, _ := cmd.Flags().GetFloat32("page")
+		page, _ := cmd.Flags().GetInt("page")
 
 		req := apiClient.SearchAPI.SearchCompanyGet(ctx).Query(query)
 		if cmd.Flags().Changed("page") {
-			req = req.Page(page)
+			req = req.Page(float32(page))
 		}
 
 		res, r, err := req.Execute()
@@ -30,6 +30,6 @@ var companyCmd = &cobra.Command{
 func init() {
 	companyCmd.Flags().StringP("query", "q", "", "Search query")
 	companyCmd.MarkFlagRequired("query")
-	companyCmd.Flags().Float32("page", 1, "Page number")
+	companyCmd.Flags().Int("page", 1, "Page number")
 	Cmd.AddCommand(companyCmd)
 }

--- a/cmd/search/keyword.go
+++ b/cmd/search/keyword.go
@@ -15,11 +15,11 @@ var keywordCmd = &cobra.Command{
 		apiClient, ctx, isVerbose := newAPIClient()
 
 		query, _ := cmd.Flags().GetString("query")
-		page, _ := cmd.Flags().GetFloat32("page")
+		page, _ := cmd.Flags().GetInt("page")
 
 		req := apiClient.SearchAPI.SearchKeywordGet(ctx).Query(query)
 		if cmd.Flags().Changed("page") {
-			req = req.Page(page)
+			req = req.Page(float32(page))
 		}
 
 		res, r, err := req.Execute()
@@ -30,6 +30,6 @@ var keywordCmd = &cobra.Command{
 func init() {
 	keywordCmd.Flags().StringP("query", "q", "", "Search query")
 	keywordCmd.MarkFlagRequired("query")
-	keywordCmd.Flags().Float32("page", 1, "Page number")
+	keywordCmd.Flags().Int("page", 1, "Page number")
 	Cmd.AddCommand(keywordCmd)
 }

--- a/cmd/search/movies.go
+++ b/cmd/search/movies.go
@@ -20,10 +20,10 @@ var moviesCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		apiClient, ctx, isVerbose := newAPIClient()
 
-		page, _ := cmd.Flags().GetFloat32("page")
+		page, _ := cmd.Flags().GetInt("page")
 		language, _ := cmd.Flags().GetString("language")
 		genre, _ := cmd.Flags().GetString("genre")
-		studio, _ := cmd.Flags().GetFloat32("studio")
+		studio, _ := cmd.Flags().GetInt("studio")
 		keywords, _ := cmd.Flags().GetString("keywords")
 		excludeKeywords, _ := cmd.Flags().GetString("exclude-keywords")
 		sortBy, _ := cmd.Flags().GetString("sort-by")
@@ -32,7 +32,7 @@ var moviesCmd = &cobra.Command{
 
 		req := apiClient.SearchAPI.DiscoverMoviesGet(ctx)
 		if cmd.Flags().Changed("page") {
-			req = req.Page(page)
+			req = req.Page(float32(page))
 		}
 		if cmd.Flags().Changed("language") {
 			req = req.Language(language)
@@ -41,7 +41,7 @@ var moviesCmd = &cobra.Command{
 			req = req.Genre(genre)
 		}
 		if cmd.Flags().Changed("studio") {
-			req = req.Studio(studio)
+			req = req.Studio(float32(studio))
 		}
 		if cmd.Flags().Changed("keywords") {
 			req = req.Keywords(keywords)
@@ -65,10 +65,10 @@ var moviesCmd = &cobra.Command{
 }
 
 func init() {
-	moviesCmd.Flags().Float32("page", 1, "Page number")
+	moviesCmd.Flags().Int("page", 1, "Page number")
 	moviesCmd.Flags().String("language", "en", "Language code")
 	moviesCmd.Flags().String("genre", "", "Genre ID")
-	moviesCmd.Flags().Float32("studio", 0, "Studio ID")
+	moviesCmd.Flags().Int("studio", 0, "Studio ID")
 	moviesCmd.Flags().String("keywords", "", "Keyword IDs")
 	moviesCmd.Flags().String("exclude-keywords", "", "Keyword IDs to exclude")
 	moviesCmd.Flags().String("sort-by", "popularity.desc", "Sort by field")

--- a/cmd/search/multi.go
+++ b/cmd/search/multi.go
@@ -18,12 +18,12 @@ var multiCmd = &cobra.Command{
 		apiClient, ctx, isVerbose := newAPIClient()
 
 		query, _ := cmd.Flags().GetString("query")
-		page, _ := cmd.Flags().GetFloat32("page")
+		page, _ := cmd.Flags().GetInt("page")
 		language, _ := cmd.Flags().GetString("language")
 
 		req := apiClient.SearchAPI.SearchGet(ctx).Query(query)
 		if cmd.Flags().Changed("page") {
-			req = req.Page(page)
+			req = req.Page(float32(page))
 		}
 		if cmd.Flags().Changed("language") {
 			req = req.Language(language)
@@ -37,7 +37,7 @@ var multiCmd = &cobra.Command{
 func init() {
 	multiCmd.Flags().StringP("query", "q", "", "Search query")
 	multiCmd.MarkFlagRequired("query")
-	multiCmd.Flags().Float32("page", 1, "Page number")
+	multiCmd.Flags().Int("page", 1, "Page number")
 	multiCmd.Flags().String("language", "en", "Language code")
 	Cmd.AddCommand(multiCmd)
 }

--- a/cmd/search/trending.go
+++ b/cmd/search/trending.go
@@ -17,14 +17,14 @@ var trendingCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		apiClient, ctx, isVerbose := newAPIClient()
 
-		page, _ := cmd.Flags().GetFloat32("page")
+		page, _ := cmd.Flags().GetInt("page")
 		language, _ := cmd.Flags().GetString("language")
 		mediaType, _ := cmd.Flags().GetString("media-type")
 		timeWindow, _ := cmd.Flags().GetString("time-window")
 
 		req := apiClient.SearchAPI.DiscoverTrendingGet(ctx)
 		if cmd.Flags().Changed("page") {
-			req = req.Page(page)
+			req = req.Page(float32(page))
 		}
 		if cmd.Flags().Changed("language") {
 			req = req.Language(language)
@@ -42,7 +42,7 @@ var trendingCmd = &cobra.Command{
 }
 
 func init() {
-	trendingCmd.Flags().Float32("page", 1, "Page number")
+	trendingCmd.Flags().Int("page", 1, "Page number")
 	trendingCmd.Flags().String("language", "en", "Language code")
 	trendingCmd.Flags().String("media-type", "all", "Media type (all, movie, tv)")
 	trendingCmd.Flags().String("time-window", "day", "Time window (day, week)")

--- a/cmd/search/tv.go
+++ b/cmd/search/tv.go
@@ -17,10 +17,10 @@ var tvCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		apiClient, ctx, isVerbose := newAPIClient()
 
-		page, _ := cmd.Flags().GetFloat32("page")
+		page, _ := cmd.Flags().GetInt("page")
 		language, _ := cmd.Flags().GetString("language")
 		genre, _ := cmd.Flags().GetString("genre")
-		network, _ := cmd.Flags().GetFloat32("network")
+		network, _ := cmd.Flags().GetInt("network")
 		keywords, _ := cmd.Flags().GetString("keywords")
 		excludeKeywords, _ := cmd.Flags().GetString("exclude-keywords")
 		sortBy, _ := cmd.Flags().GetString("sort-by")
@@ -29,7 +29,7 @@ var tvCmd = &cobra.Command{
 
 		req := apiClient.SearchAPI.DiscoverTvGet(ctx)
 		if cmd.Flags().Changed("page") {
-			req = req.Page(page)
+			req = req.Page(float32(page))
 		}
 		if cmd.Flags().Changed("language") {
 			req = req.Language(language)
@@ -38,7 +38,7 @@ var tvCmd = &cobra.Command{
 			req = req.Genre(genre)
 		}
 		if cmd.Flags().Changed("network") {
-			req = req.Network(network)
+			req = req.Network(float32(network))
 		}
 		if cmd.Flags().Changed("keywords") {
 			req = req.Keywords(keywords)
@@ -62,10 +62,10 @@ var tvCmd = &cobra.Command{
 }
 
 func init() {
-	tvCmd.Flags().Float32("page", 1, "Page number")
+	tvCmd.Flags().Int("page", 1, "Page number")
 	tvCmd.Flags().String("language", "en", "Language code")
 	tvCmd.Flags().String("genre", "", "Genre ID")
-	tvCmd.Flags().Float32("network", 0, "Network ID")
+	tvCmd.Flags().Int("network", 0, "Network ID")
 	tvCmd.Flags().String("keywords", "", "Keyword IDs")
 	tvCmd.Flags().String("exclude-keywords", "", "Keyword IDs to exclude")
 	tvCmd.Flags().String("sort-by", "popularity.desc", "Sort by field")

--- a/cmd/service/radarr.go
+++ b/cmd/service/radarr.go
@@ -25,7 +25,7 @@ var radarrGetCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		apiClient, ctx, isVerbose := apiutil.NewAPIClient()
 
-		id, err := strconv.ParseFloat(args[0], 32)
+		id, err := strconv.ParseInt(args[0], 10, 64)
 		if err != nil {
 			return err
 		}

--- a/cmd/service/sonarr.go
+++ b/cmd/service/sonarr.go
@@ -25,7 +25,7 @@ var sonarrGetCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		apiClient, ctx, isVerbose := apiutil.NewAPIClient()
 
-		id, err := strconv.ParseFloat(args[0], 32)
+		id, err := strconv.ParseInt(args[0], 10, 64)
 		if err != nil {
 			return err
 		}
@@ -42,7 +42,7 @@ var sonarrLookupCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		apiClient, ctx, isVerbose := apiutil.NewAPIClient()
 
-		id, err := strconv.ParseFloat(args[0], 32)
+		id, err := strconv.ParseInt(args[0], 10, 64)
 		if err != nil {
 			return err
 		}

--- a/cmd/tmdb/network.go
+++ b/cmd/tmdb/network.go
@@ -14,7 +14,7 @@ var networkCmd = &cobra.Command{
 	Short: "Get TV network details",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		id, err := strconv.ParseFloat(args[0], 32)
+		id, err := strconv.ParseInt(args[0], 10, 64)
 		if err != nil {
 			return fmt.Errorf("invalid network ID: %s", args[0])
 		}

--- a/cmd/tmdb/studio.go
+++ b/cmd/tmdb/studio.go
@@ -14,7 +14,7 @@ var studioCmd = &cobra.Command{
 	Short: "Get movie studio details",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		id, err := strconv.ParseFloat(args[0], 32)
+		id, err := strconv.ParseInt(args[0], 10, 64)
 		if err != nil {
 			return fmt.Errorf("invalid studio ID: %s", args[0])
 		}

--- a/cmd/tv/get.go
+++ b/cmd/tv/get.go
@@ -20,7 +20,7 @@ var getCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		apiClient, ctx, isVerbose := apiutil.NewAPIClient()
 
-		tvId, err := strconv.ParseFloat(args[0], 32)
+		tvId, err := strconv.ParseInt(args[0], 10, 64)
 		if err != nil {
 			return err
 		}

--- a/cmd/tv/ratings.go
+++ b/cmd/tv/ratings.go
@@ -17,7 +17,7 @@ var ratingsCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		apiClient, ctx, isVerbose := apiutil.NewAPIClient()
 
-		tvId, err := strconv.ParseFloat(args[0], 32)
+		tvId, err := strconv.ParseInt(args[0], 10, 64)
 		if err != nil {
 			return err
 		}

--- a/cmd/tv/recommendations.go
+++ b/cmd/tv/recommendations.go
@@ -20,15 +20,15 @@ var recommendationsCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		apiClient, ctx, isVerbose := apiutil.NewAPIClient()
 
-		tvId, err := strconv.ParseFloat(args[0], 32)
+		tvId, err := strconv.ParseInt(args[0], 10, 64)
 		if err != nil {
 			return err
 		}
 
 		req := apiClient.TvAPI.TvTvIdRecommendationsGet(ctx, float32(tvId))
 		if cmd.Flags().Changed("page") {
-			page, _ := cmd.Flags().GetFloat32("page")
-			req = req.Page(page)
+			page, _ := cmd.Flags().GetInt("page")
+			req = req.Page(float32(page))
 		}
 		if cmd.Flags().Changed("language") {
 			language, _ := cmd.Flags().GetString("language")
@@ -41,7 +41,7 @@ var recommendationsCmd = &cobra.Command{
 }
 
 func init() {
-	recommendationsCmd.Flags().Float32("page", 1, "Page number")
+	recommendationsCmd.Flags().Int("page", 1, "Page number")
 	recommendationsCmd.Flags().String("language", "en", "Language code")
 	Cmd.AddCommand(recommendationsCmd)
 }

--- a/cmd/tv/season.go
+++ b/cmd/tv/season.go
@@ -20,11 +20,11 @@ var seasonCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		apiClient, ctx, isVerbose := apiutil.NewAPIClient()
 
-		tvId, err := strconv.ParseFloat(args[0], 32)
+		tvId, err := strconv.ParseInt(args[0], 10, 64)
 		if err != nil {
 			return err
 		}
-		seasonNumber, err := strconv.ParseFloat(args[1], 32)
+		seasonNumber, err := strconv.ParseInt(args[1], 10, 64)
 		if err != nil {
 			return err
 		}

--- a/cmd/tv/similar.go
+++ b/cmd/tv/similar.go
@@ -17,15 +17,15 @@ var similarCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		apiClient, ctx, isVerbose := apiutil.NewAPIClient()
 
-		tvId, err := strconv.ParseFloat(args[0], 32)
+		tvId, err := strconv.ParseInt(args[0], 10, 64)
 		if err != nil {
 			return err
 		}
 
 		req := apiClient.TvAPI.TvTvIdSimilarGet(ctx, float32(tvId))
 		if cmd.Flags().Changed("page") {
-			page, _ := cmd.Flags().GetFloat32("page")
-			req = req.Page(page)
+			page, _ := cmd.Flags().GetInt("page")
+			req = req.Page(float32(page))
 		}
 		if cmd.Flags().Changed("language") {
 			language, _ := cmd.Flags().GetString("language")
@@ -38,7 +38,7 @@ var similarCmd = &cobra.Command{
 }
 
 func init() {
-	similarCmd.Flags().Float32("page", 1, "Page number")
+	similarCmd.Flags().Int("page", 1, "Page number")
 	similarCmd.Flags().String("language", "en", "Language code")
 	Cmd.AddCommand(similarCmd)
 }

--- a/cmd/users/create.go
+++ b/cmd/users/create.go
@@ -18,7 +18,7 @@ var createCmd = &cobra.Command{
 
 		email, _ := cmd.Flags().GetString("email")
 		username, _ := cmd.Flags().GetString("username")
-		permissions, _ := cmd.Flags().GetFloat32("permissions")
+		permissions, _ := cmd.Flags().GetInt("permissions")
 
 		body := api.UserPostRequest{
 			Email: &email,
@@ -27,7 +27,8 @@ var createCmd = &cobra.Command{
 			body.Username = &username
 		}
 		if cmd.Flags().Changed("permissions") {
-			body.Permissions = &permissions
+			p := float32(permissions)
+			body.Permissions = &p
 		}
 
 		res, r, err := apiClient.UsersAPI.UserPost(ctx).UserPostRequest(body).Execute()
@@ -57,6 +58,6 @@ func init() {
 	createCmd.Flags().String("email", "", "Email address (required)")
 	createCmd.MarkFlagRequired("email")
 	createCmd.Flags().String("username", "", "Username")
-	createCmd.Flags().Float32("permissions", 0, "Initial permissions bitmask")
+	createCmd.Flags().Int("permissions", 0, "Initial permissions bitmask")
 	Cmd.AddCommand(createCmd)
 }

--- a/cmd/users/delete.go
+++ b/cmd/users/delete.go
@@ -16,7 +16,7 @@ var deleteCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		apiClient, ctx, isVerbose := apiutil.NewAPIClient()
 
-		userId, err := strconv.ParseFloat(args[0], 32)
+		userId, err := strconv.ParseInt(args[0], 10, 64)
 		if err != nil {
 			return fmt.Errorf("invalid userId: %w", err)
 		}

--- a/cmd/users/get.go
+++ b/cmd/users/get.go
@@ -17,7 +17,7 @@ var getCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		apiClient, ctx, isVerbose := apiutil.NewAPIClient()
 
-		userId, err := strconv.ParseFloat(args[0], 32)
+		userId, err := strconv.ParseInt(args[0], 10, 64)
 		if err != nil {
 			return fmt.Errorf("invalid userId: %w", err)
 		}

--- a/cmd/users/linked_accounts.go
+++ b/cmd/users/linked_accounts.go
@@ -21,7 +21,7 @@ var linkPlexCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		apiClient, ctx, isVerbose := apiutil.NewAPIClient()
-		userId, err := strconv.ParseFloat(args[0], 32)
+		userId, err := strconv.ParseInt(args[0], 10, 64)
 		if err != nil {
 			return fmt.Errorf("invalid userId: %w", err)
 		}
@@ -42,7 +42,7 @@ var unlinkPlexCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		apiClient, ctx, isVerbose := apiutil.NewAPIClient()
-		userId, err := strconv.ParseFloat(args[0], 32)
+		userId, err := strconv.ParseInt(args[0], 10, 64)
 		if err != nil {
 			return fmt.Errorf("invalid userId: %w", err)
 		}
@@ -58,7 +58,7 @@ var linkJellyfinCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		apiClient, ctx, isVerbose := apiutil.NewAPIClient()
-		userId, err := strconv.ParseFloat(args[0], 32)
+		userId, err := strconv.ParseInt(args[0], 10, 64)
 		if err != nil {
 			return fmt.Errorf("invalid userId: %w", err)
 		}
@@ -84,7 +84,7 @@ var unlinkJellyfinCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		apiClient, ctx, isVerbose := apiutil.NewAPIClient()
-		userId, err := strconv.ParseFloat(args[0], 32)
+		userId, err := strconv.ParseInt(args[0], 10, 64)
 		if err != nil {
 			return fmt.Errorf("invalid userId: %w", err)
 		}

--- a/cmd/users/list.go
+++ b/cmd/users/list.go
@@ -15,18 +15,18 @@ var listCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		apiClient, ctx, isVerbose := apiutil.NewAPIClient()
 
-		take, _ := cmd.Flags().GetFloat32("take")
-		skip, _ := cmd.Flags().GetFloat32("skip")
+		take, _ := cmd.Flags().GetInt("take")
+		skip, _ := cmd.Flags().GetInt("skip")
 		sort, _ := cmd.Flags().GetString("sort")
 		query, _ := cmd.Flags().GetString("q")
 		includeIds, _ := cmd.Flags().GetString("include-ids")
 
 		req := apiClient.UsersAPI.UserGet(ctx)
 		if cmd.Flags().Changed("take") {
-			req = req.Take(take)
+			req = req.Take(float32(take))
 		}
 		if cmd.Flags().Changed("skip") {
-			req = req.Skip(skip)
+			req = req.Skip(float32(skip))
 		}
 		if cmd.Flags().Changed("sort") {
 			req = req.Sort(sort)
@@ -62,8 +62,8 @@ var listCmd = &cobra.Command{
 }
 
 func init() {
-	listCmd.Flags().Float32("take", 0, "Number of items to take")
-	listCmd.Flags().Float32("skip", 0, "Number of items to skip")
+	listCmd.Flags().Int("take", 0, "Number of items to take")
+	listCmd.Flags().Int("skip", 0, "Number of items to skip")
 	listCmd.Flags().String("sort", "id", "Field to sort by")
 	listCmd.Flags().String("q", "", "Search query")
 	listCmd.Flags().String("include-ids", "", "Comma-separated IDs to include")

--- a/cmd/users/password.go
+++ b/cmd/users/password.go
@@ -92,7 +92,7 @@ var passwordGetCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		apiClient, ctx, isVerbose := apiutil.NewAPIClient()
-		userId, err := strconv.ParseFloat(args[0], 32)
+		userId, err := strconv.ParseInt(args[0], 10, 64)
 		if err != nil {
 			return fmt.Errorf("invalid userId: %w", err)
 		}
@@ -126,7 +126,7 @@ var passwordSetCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		apiClient, ctx, isVerbose := apiutil.NewAPIClient()
-		userId, err := strconv.ParseFloat(args[0], 32)
+		userId, err := strconv.ParseInt(args[0], 10, 64)
 		if err != nil {
 			return fmt.Errorf("invalid userId: %w", err)
 		}

--- a/cmd/users/push_subscriptions.go
+++ b/cmd/users/push_subscriptions.go
@@ -47,7 +47,7 @@ var pushSubscriptionsListCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		apiClient, ctx, isVerbose := apiutil.NewAPIClient()
-		userId, err := strconv.ParseFloat(args[0], 32)
+		userId, err := strconv.ParseInt(args[0], 10, 64)
 		if err != nil {
 			return fmt.Errorf("invalid userId: %w", err)
 		}
@@ -81,7 +81,7 @@ var pushSubscriptionsGetCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(2),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		apiClient, ctx, isVerbose := apiutil.NewAPIClient()
-		userId, err := strconv.ParseFloat(args[0], 32)
+		userId, err := strconv.ParseInt(args[0], 10, 64)
 		if err != nil {
 			return fmt.Errorf("invalid userId: %w", err)
 		}
@@ -116,7 +116,7 @@ var pushSubscriptionsDeleteCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(2),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		apiClient, ctx, isVerbose := apiutil.NewAPIClient()
-		userId, err := strconv.ParseFloat(args[0], 32)
+		userId, err := strconv.ParseInt(args[0], 10, 64)
 		if err != nil {
 			return fmt.Errorf("invalid userId: %w", err)
 		}

--- a/cmd/users/quota.go
+++ b/cmd/users/quota.go
@@ -17,7 +17,7 @@ var quotaCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		apiClient, ctx, isVerbose := apiutil.NewAPIClient()
 
-		userId, err := strconv.ParseFloat(args[0], 32)
+		userId, err := strconv.ParseInt(args[0], 10, 64)
 		if err != nil {
 			return fmt.Errorf("invalid userId: %w", err)
 		}

--- a/cmd/users/requests.go
+++ b/cmd/users/requests.go
@@ -17,20 +17,20 @@ var requestsCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		apiClient, ctx, isVerbose := apiutil.NewAPIClient()
 
-		userId, err := strconv.ParseFloat(args[0], 32)
+		userId, err := strconv.ParseInt(args[0], 10, 64)
 		if err != nil {
 			return fmt.Errorf("invalid userId: %w", err)
 		}
 
-		take, _ := cmd.Flags().GetFloat32("take")
-		skip, _ := cmd.Flags().GetFloat32("skip")
+		take, _ := cmd.Flags().GetInt("take")
+		skip, _ := cmd.Flags().GetInt("skip")
 
 		req := apiClient.UsersAPI.UserUserIdRequestsGet(ctx, float32(userId))
 		if cmd.Flags().Changed("take") {
-			req = req.Take(take)
+			req = req.Take(float32(take))
 		}
 		if cmd.Flags().Changed("skip") {
-			req = req.Skip(skip)
+			req = req.Skip(float32(skip))
 		}
 
 		res, r, err := req.Execute()
@@ -57,7 +57,7 @@ var requestsCmd = &cobra.Command{
 }
 
 func init() {
-	requestsCmd.Flags().Float32("take", 0, "Number of items to take")
-	requestsCmd.Flags().Float32("skip", 0, "Number of items to skip")
+	requestsCmd.Flags().Int("take", 0, "Number of items to take")
+	requestsCmd.Flags().Int("skip", 0, "Number of items to skip")
 	Cmd.AddCommand(requestsCmd)
 }

--- a/cmd/users/settings.go
+++ b/cmd/users/settings.go
@@ -22,7 +22,7 @@ var settingsGetCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		apiClient, ctx, isVerbose := apiutil.NewAPIClient()
-		userId, err := strconv.ParseFloat(args[0], 32)
+		userId, err := strconv.ParseInt(args[0], 10, 64)
 		if err != nil {
 			return fmt.Errorf("invalid userId: %w", err)
 		}
@@ -56,7 +56,7 @@ var settingsUpdateCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		apiClient, ctx, isVerbose := apiutil.NewAPIClient()
-		userId, err := strconv.ParseFloat(args[0], 32)
+		userId, err := strconv.ParseInt(args[0], 10, 64)
 		if err != nil {
 			return fmt.Errorf("invalid userId: %w", err)
 		}
@@ -92,20 +92,20 @@ var settingsUpdateCmd = &cobra.Command{
 			body.SetOriginalLanguage(v)
 		}
 		if cmd.Flags().Changed("movie-quota-limit") {
-			v, _ := cmd.Flags().GetFloat32("movie-quota-limit")
-			body.SetMovieQuotaLimit(v)
+			v, _ := cmd.Flags().GetInt("movie-quota-limit")
+			body.SetMovieQuotaLimit(float32(v))
 		}
 		if cmd.Flags().Changed("movie-quota-days") {
-			v, _ := cmd.Flags().GetFloat32("movie-quota-days")
-			body.SetMovieQuotaDays(v)
+			v, _ := cmd.Flags().GetInt("movie-quota-days")
+			body.SetMovieQuotaDays(float32(v))
 		}
 		if cmd.Flags().Changed("tv-quota-limit") {
-			v, _ := cmd.Flags().GetFloat32("tv-quota-limit")
-			body.SetTvQuotaLimit(v)
+			v, _ := cmd.Flags().GetInt("tv-quota-limit")
+			body.SetTvQuotaLimit(float32(v))
 		}
 		if cmd.Flags().Changed("tv-quota-days") {
-			v, _ := cmd.Flags().GetFloat32("tv-quota-days")
-			body.SetTvQuotaDays(v)
+			v, _ := cmd.Flags().GetInt("tv-quota-days")
+			body.SetTvQuotaDays(float32(v))
 		}
 		if cmd.Flags().Changed("watchlist-sync-movies") {
 			v, _ := cmd.Flags().GetBool("watchlist-sync-movies")
@@ -145,7 +145,7 @@ var settingsNotificationsGetCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		apiClient, ctx, isVerbose := apiutil.NewAPIClient()
-		userId, err := strconv.ParseFloat(args[0], 32)
+		userId, err := strconv.ParseInt(args[0], 10, 64)
 		if err != nil {
 			return fmt.Errorf("invalid userId: %w", err)
 		}
@@ -179,7 +179,7 @@ var settingsNotificationsUpdateCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		apiClient, ctx, isVerbose := apiutil.NewAPIClient()
-		userId, err := strconv.ParseFloat(args[0], 32)
+		userId, err := strconv.ParseInt(args[0], 10, 64)
 		if err != nil {
 			return fmt.Errorf("invalid userId: %w", err)
 		}
@@ -219,7 +219,7 @@ var settingsPermissionsGetCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		apiClient, ctx, isVerbose := apiutil.NewAPIClient()
-		userId, err := strconv.ParseFloat(args[0], 32)
+		userId, err := strconv.ParseInt(args[0], 10, 64)
 		if err != nil {
 			return fmt.Errorf("invalid userId: %w", err)
 		}
@@ -253,14 +253,14 @@ var settingsPermissionsSetCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		apiClient, ctx, isVerbose := apiutil.NewAPIClient()
-		userId, err := strconv.ParseFloat(args[0], 32)
+		userId, err := strconv.ParseInt(args[0], 10, 64)
 		if err != nil {
 			return fmt.Errorf("invalid userId: %w", err)
 		}
 
-		permissions, _ := cmd.Flags().GetFloat32("permissions")
+		permissions, _ := cmd.Flags().GetInt("permissions")
 		body := api.UserUserIdSettingsPermissionsPostRequest{
-			Permissions: permissions,
+			Permissions: float32(permissions),
 		}
 
 		res, r, err := apiClient.UsersAPI.UserUserIdSettingsPermissionsPost(ctx, float32(userId)).UserUserIdSettingsPermissionsPostRequest(body).Execute()
@@ -294,17 +294,17 @@ func init() {
 	settingsUpdateCmd.Flags().String("discover-region", "", "New discover region")
 	settingsUpdateCmd.Flags().String("streaming-region", "", "New streaming region")
 	settingsUpdateCmd.Flags().String("original-language", "", "New original language")
-	settingsUpdateCmd.Flags().Float32("movie-quota-limit", 0, "New movie quota limit")
-	settingsUpdateCmd.Flags().Float32("movie-quota-days", 0, "New movie quota days")
-	settingsUpdateCmd.Flags().Float32("tv-quota-limit", 0, "New TV quota limit")
-	settingsUpdateCmd.Flags().Float32("tv-quota-days", 0, "New TV quota days")
+	settingsUpdateCmd.Flags().Int("movie-quota-limit", 0, "New movie quota limit")
+	settingsUpdateCmd.Flags().Int("movie-quota-days", 0, "New movie quota days")
+	settingsUpdateCmd.Flags().Int("tv-quota-limit", 0, "New TV quota limit")
+	settingsUpdateCmd.Flags().Int("tv-quota-days", 0, "New TV quota days")
 	settingsUpdateCmd.Flags().Bool("watchlist-sync-movies", false, "Enable/disable movie watchlist sync")
 	settingsUpdateCmd.Flags().Bool("watchlist-sync-tv", false, "Enable/disable TV watchlist sync")
 
 	settingsNotificationsUpdateCmd.Flags().String("json", "", "Notification settings JSON (required)")
 	settingsNotificationsUpdateCmd.MarkFlagRequired("json")
 
-	settingsPermissionsSetCmd.Flags().Float32("permissions", 0, "Permissions bitmask (required)")
+	settingsPermissionsSetCmd.Flags().Int("permissions", 0, "Permissions bitmask (required)")
 	settingsPermissionsSetCmd.MarkFlagRequired("permissions")
 
 	settingsCmd.AddCommand(settingsGetCmd, settingsUpdateCmd, settingsNotificationsGetCmd, settingsNotificationsUpdateCmd, settingsPermissionsGetCmd, settingsPermissionsSetCmd)

--- a/cmd/users/update.go
+++ b/cmd/users/update.go
@@ -18,14 +18,14 @@ var updateCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		apiClient, ctx, isVerbose := apiutil.NewAPIClient()
 
-		userId, err := strconv.ParseFloat(args[0], 32)
+		userId, err := strconv.ParseInt(args[0], 10, 64)
 		if err != nil {
 			return fmt.Errorf("invalid userId: %w", err)
 		}
 
 		username, _ := cmd.Flags().GetString("username")
 		email, _ := cmd.Flags().GetString("email")
-		permissions, _ := cmd.Flags().GetFloat32("permissions")
+		permissions, _ := cmd.Flags().GetInt("permissions")
 
 		body := api.UserUpdatePayload{}
 		changed := false
@@ -38,7 +38,8 @@ var updateCmd = &cobra.Command{
 			changed = true
 		}
 		if cmd.Flags().Changed("permissions") {
-			body.Permissions = &permissions
+			p := float32(permissions)
+			body.Permissions = &p
 			changed = true
 		}
 		if !changed {
@@ -71,6 +72,6 @@ var updateCmd = &cobra.Command{
 func init() {
 	updateCmd.Flags().String("username", "", "New username")
 	updateCmd.Flags().String("email", "", "New email address")
-	updateCmd.Flags().Float32("permissions", 0, "New permissions bitmask")
+	updateCmd.Flags().Int("permissions", 0, "New permissions bitmask")
 	Cmd.AddCommand(updateCmd)
 }

--- a/cmd/users/watch_data.go
+++ b/cmd/users/watch_data.go
@@ -17,7 +17,7 @@ var watchDataCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		apiClient, ctx, isVerbose := apiutil.NewAPIClient()
 
-		userId, err := strconv.ParseFloat(args[0], 32)
+		userId, err := strconv.ParseInt(args[0], 10, 64)
 		if err != nil {
 			return fmt.Errorf("invalid userId: %w", err)
 		}

--- a/cmd/users/watchlist.go
+++ b/cmd/users/watchlist.go
@@ -17,16 +17,16 @@ var watchlistCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		apiClient, ctx, isVerbose := apiutil.NewAPIClient()
 
-		userId, err := strconv.ParseFloat(args[0], 32)
+		userId, err := strconv.ParseInt(args[0], 10, 64)
 		if err != nil {
 			return fmt.Errorf("invalid userId: %w", err)
 		}
 
-		page, _ := cmd.Flags().GetFloat32("page")
+		page, _ := cmd.Flags().GetInt("page")
 
 		req := apiClient.UsersAPI.UserUserIdWatchlistGet(ctx, float32(userId))
 		if cmd.Flags().Changed("page") {
-			req = req.Page(page)
+			req = req.Page(float32(page))
 		}
 
 		res, r, err := req.Execute()
@@ -53,6 +53,6 @@ var watchlistCmd = &cobra.Command{
 }
 
 func init() {
-	watchlistCmd.Flags().Float32("page", 1, "Page number to retrieve")
+	watchlistCmd.Flags().Int("page", 1, "Page number to retrieve")
 	Cmd.AddCommand(watchlistCmd)
 }

--- a/cmd/watchlist/add.go
+++ b/cmd/watchlist/add.go
@@ -16,8 +16,8 @@ var addCmd = &cobra.Command{
 
 		body := api.NewWatchlist()
 		if cmd.Flags().Changed("tmdb-id") {
-			v, _ := cmd.Flags().GetFloat32("tmdb-id")
-			body.SetTmdbId(v)
+			v, _ := cmd.Flags().GetInt("tmdb-id")
+			body.SetTmdbId(float32(v))
 		}
 		if cmd.Flags().Changed("media-type") {
 			v, _ := cmd.Flags().GetString("media-type")
@@ -38,7 +38,7 @@ var addCmd = &cobra.Command{
 }
 
 func init() {
-	addCmd.Flags().Float32("tmdb-id", 0, "TMDB ID of the media (required)")
+	addCmd.Flags().Int("tmdb-id", 0, "TMDB ID of the media (required)")
 	addCmd.MarkFlagRequired("tmdb-id")
 	addCmd.Flags().String("media-type", "", "Media type: movie or tv (required)")
 	addCmd.MarkFlagRequired("media-type")

--- a/tests/int_flags_test.go
+++ b/tests/int_flags_test.go
@@ -1,0 +1,93 @@
+package tests
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"seerr-cli/cmd"
+	"seerr-cli/cmd/apiutil"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// setupTestServer creates a minimal httptest server and sets the override URL.
+// Callers must call the returned cleanup func after the test.
+func setupTestServer(t *testing.T) func() {
+	t.Helper()
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{}`))
+	}))
+	apiutil.OverrideServerURL = ts.URL + "/api/v1"
+	viper.Set("seerr.server", ts.URL)
+	return func() {
+		ts.Close()
+		apiutil.OverrideServerURL = ""
+	}
+}
+
+func runRootCmd(t *testing.T, args []string) (string, error) {
+	t.Helper()
+	viper.Reset()
+	viper.Set("seerr.server", "http://localhost:5055")
+	b := new(bytes.Buffer)
+	cmd.RootCmd.SetOut(b)
+	cmd.RootCmd.SetErr(b)
+	cmd.RootCmd.SetArgs(args)
+	err := cmd.RootCmd.Execute()
+	return b.String(), err
+}
+
+// TestCLIRejectsDecimalMovieID verifies that passing a decimal as a movie ID
+// returns a parse error; movie IDs must be integers.
+func TestCLIRejectsDecimalMovieID(t *testing.T) {
+	cleanup := setupTestServer(t)
+	defer cleanup()
+
+	_, err := runRootCmd(t, []string{"movies", "get", "603.5"})
+	require.Error(t, err, "expected error for decimal movie ID")
+}
+
+// TestCLIRejectsDecimalTVID verifies that passing a decimal as a TV ID returns
+// a parse error.
+func TestCLIRejectsDecimalTVID(t *testing.T) {
+	cleanup := setupTestServer(t)
+	defer cleanup()
+
+	_, err := runRootCmd(t, []string{"tv", "get", "1399.5"})
+	require.Error(t, err, "expected error for decimal TV ID")
+}
+
+// TestCLIRejectsDecimalPageFlag verifies that --page flag rejects fractional
+// values; page numbers must be integers.
+func TestCLIRejectsDecimalPageFlag(t *testing.T) {
+	cleanup := setupTestServer(t)
+	defer cleanup()
+
+	_, err := runRootCmd(t, []string{"movies", "similar", "603", "--page", "1.5"})
+	require.Error(t, err, "expected error for decimal --page flag")
+}
+
+// TestCLIRejectsDecimalMediaIDFlag verifies that --media-id flag rejects
+// fractional values.
+func TestCLIRejectsDecimalMediaIDFlag(t *testing.T) {
+	cleanup := setupTestServer(t)
+	defer cleanup()
+
+	_, err := runRootCmd(t, []string{"request", "create", "--media-type", "movie", "--media-id", "123.5"})
+	require.Error(t, err, "expected error for decimal --media-id flag")
+}
+
+// TestCLIAcceptsIntegerMovieID verifies that valid integer IDs continue to work.
+func TestCLIAcceptsIntegerMovieID(t *testing.T) {
+	cleanup := setupTestServer(t)
+	defer cleanup()
+
+	_, err := runRootCmd(t, []string{"movies", "get", "603"})
+	assert.NoError(t, err, "expected no error for integer movie ID")
+}


### PR DESCRIPTION
## Summary

Replace all hand-written `float32` flag types and `ParseFloat` calls with integer types throughout CLI handlers and MCP tool handlers. The auto-generated `pkg/api/` client still uses `float32` for API parameters; `float32(id)` casts remain only at those API call boundaries.

Closes #69

## Changes

### Step 1 — CLI positional arg parsing
- Replaced `strconv.ParseFloat(args[0], 32)` with `strconv.ParseInt(args[0], 10, 64)` for all commands that accept a numeric ID as a positional argument (`movies`, `tv`, `users`, `person`, `collection`, `service`, `issue`, `tmdb`, `other`, `overriderule`)
- Season numbers in `request create/update` now also use `ParseInt` (the `[]float32` slice stays because the generated API requires it)

### Step 2 — Cobra flag types
- Changed all `cmd.Flags().Float32("xxx", ...)` / `GetFloat32("xxx")` flag registrations to `Int` for pagination params (`--page`, `--take`, `--skip`), ID params (`--media-id`, `--tmdb-id`, `--requested-by`, `--server-id`, `--profile-id`, `--language-profile-id`, `--user-id`, `--tvdb-id`, `--network`, `--studio`, `--permissions`, etc.)

### Step 3 — MCP tool handlers
- Replaced `req.RequireFloat` → `req.RequireInt` and `req.GetFloat` → `req.GetInt` for all integer IDs and pagination parameters in all MCP tool files

### Step 4 — GenreMap
- Changed `GenreMap` key type from `float32` to `int` in `cmd/mcp/enrich.go`

## Test plan

- [ ] `go test -v ./...` passes
- [ ] `go fmt ./...` produces no diff
- [ ] `go build` succeeds
- New tests in `tests/int_flags_test.go` verify decimal IDs and `--page` flags are now rejected with a parse error

## Checklist

- [x] New tests added for new behaviour
- [ ] Documentation updated (README, command `--help`, comments)
- [x] No unrelated changes included